### PR TITLE
fix(build): declare profile page as dynamic

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,11 +1,13 @@
 import { createServerSupabaseClient} from'@/utils/supabase/server'
 import { redirect} from'next/navigation'
+import { connection } from 'next/server'
 import { ProfileClientWrapper} from'@/components/profile/ProfileClientWrapper'
 import type { UserProfile} from'@/types/user-profile'
 import type { UserStats} from'@/types/user-stats'
 import type { Achievement} from'@/types/achievement'
 
 export default async function ProfilePage() {
+ await connection()
  const supabase = createServerSupabaseClient()
  const { data: { user}, error: userError} = await supabase.auth.getUser()
  


### PR DESCRIPTION
## Summary
- declare the profile route dynamic explicitly before server-side auth access
- remove the ambiguous /profile cookies warning from production builds
- keep the existing profile UI and auth behavior unchanged

## Checks
- npm run build
- npm run lint
- npm run typecheck

Closes #12

## Summary by Sourcery

Corrections de bugs :
- Empêcher les avertissements/erreurs au moment de la compilation en établissant explicitement un contexte de requête avant d’accéder à l’authentification côté serveur sur la page de profil.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent build-time warnings/errors by explicitly establishing a request context before accessing server-side auth in the profile page.

</details>