### PR TITLE
PR #41 — Login : Google OAuth + redesign split éditorial

### DIFF
--- a/src/app/[locale]/login/actions.ts
+++ b/src/app/[locale]/login/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 import { magicLinkSchema } from '@/lib/auth/schema';
 import { getClientIp, rateLimit } from '@/lib/rate-limit';
@@ -68,4 +69,50 @@ export async function sendMagicLink(
   }
 
   return { status: 'success' };
+}
+
+/**
+ * Server Action : démarre le flow OAuth Google.
+ *
+ * Sécurité :
+ *   - Rate-limit 10 req / 60s par IP
+ *   - PKCE géré côté Supabase
+ *   - `redirectTo` validé contre la redirect-allow-list Supabase
+ */
+export async function signInWithGoogle(formData: FormData): Promise<void> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`oauth:${ip}`, { limit: 10, windowMs: 60_000 });
+  if (!ok) {
+    redirect('/auth/error');
+  }
+
+  const next = formData.get('next');
+  const safeNext =
+    typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')
+      ? next
+      : '/';
+
+  const supabase = await createServerClient();
+  const origin =
+    headerList.get('origin') ??
+    `https://${headerList.get('host') ?? 'iron-track-dusky.vercel.app'}`;
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: 'google',
+    options: {
+      redirectTo: `${origin}/auth/callback?next=${encodeURIComponent(safeNext)}`,
+      queryParams: {
+        access_type: 'offline',
+        prompt: 'consent',
+      },
+    },
+  });
+
+  if (error || !data.url) {
+    redirect('/auth/error');
+  }
+
+  redirect(data.url);
 }

--- a/src/app/[locale]/login/login-form.tsx
+++ b/src/app/[locale]/login/login-form.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import { useActionState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
+import { GoogleIcon } from '@/components/icons/google';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-import { sendMagicLink, type LoginState } from './actions';
+import { sendMagicLink, signInWithGoogle, type LoginState } from './actions';
 
 const initial: LoginState = { status: 'idle' };
 
 export function LoginForm() {
   const t = useTranslations('auth');
+  const searchParams = useSearchParams();
+  const next = searchParams.get('next') ?? '/';
   const [state, action, pending] = useActionState(sendMagicLink, initial);
 
   if (state.status === 'success') {
@@ -20,50 +24,83 @@ export function LoginForm() {
       <div
         role="status"
         aria-live="polite"
-        className="border border-border bg-card p-6 text-foreground"
+        className="border-2 border-foreground bg-card p-6 text-foreground"
       >
-        <h2 className="font-display text-2xl">{t('checkEmail.title')}</h2>
-        <p className="mt-2 text-sm text-muted-foreground">{t('checkEmail.body')}</p>
+        <h2 className="font-display text-2xl leading-tight">
+          {t('checkEmail.title')}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {t('checkEmail.body')}
+        </p>
       </div>
     );
   }
 
   return (
-    <form action={action} noValidate className="flex flex-col gap-4">
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="email">{t('form.email.label')}</Label>
-        <Input
-          id="email"
-          name="email"
-          type="email"
-          autoComplete="email"
-          inputMode="email"
-          required
-          aria-invalid={state.status === 'error'}
-          aria-describedby={state.status === 'error' ? 'email-error' : undefined}
-          placeholder={t('form.email.placeholder')}
-          className="min-h-[44px]"
-        />
-        {state.status === 'error' && state.error && (
-          <p
-            id="email-error"
-            role="alert"
-            className="text-sm text-destructive"
-          >
-            {t(state.error.replace('auth.', '') as 'errors.emailInvalid')}
-          </p>
-        )}
+    <div className="flex flex-col gap-6">
+      {/* OAuth Google */}
+      <form action={signInWithGoogle}>
+        <input type="hidden" name="next" value={next} />
+        <Button
+          type="submit"
+          variant="outline"
+          className="min-h-[48px] w-full justify-center gap-3 border-2 border-foreground bg-background text-base font-medium hover:bg-foreground/5"
+        >
+          <GoogleIcon className="size-5" />
+          {t('oauth.google')}
+        </Button>
+      </form>
+
+      {/* Séparateur */}
+      <div className="flex items-center gap-3" aria-hidden="true">
+        <span className="h-px flex-1 bg-border" />
+        <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('oauth.or')}
+        </span>
+        <span className="h-px flex-1 bg-border" />
       </div>
 
-      <Button
-        type="submit"
-        disabled={pending}
-        className="min-h-[44px] w-full"
-      >
-        {pending ? t('form.submitPending') : t('form.submit')}
-      </Button>
+      {/* Magic link email */}
+      <form action={action} noValidate className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="email" className="font-mono text-xs uppercase tracking-widest">
+            {t('form.email.label')}
+          </Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            required
+            aria-invalid={state.status === 'error'}
+            aria-describedby={state.status === 'error' ? 'email-error' : undefined}
+            placeholder={t('form.email.placeholder')}
+            className="min-h-[48px] border-2 border-foreground text-base"
+          />
+          {state.status === 'error' && state.error && (
+            <p
+              id="email-error"
+              role="alert"
+              className="text-sm font-medium text-destructive"
+            >
+              {t(state.error.replace('auth.', '') as 'errors.emailInvalid')}
+            </p>
+          )}
+        </div>
 
-      <p className="text-xs text-muted-foreground">{t('form.hint')}</p>
-    </form>
+        <Button
+          type="submit"
+          disabled={pending}
+          className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+        >
+          {pending ? t('form.submitPending') : t('form.submit')}
+        </Button>
+
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {t('form.hint')}
+        </p>
+      </form>
+    </div>
   );
 }

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Suspense } from 'react';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LOCALES, type Locale } from '@/i18n/request';
@@ -31,20 +33,92 @@ export default async function LoginPage({ params }: LoginPageProps) {
     : 'fr';
   setRequestLocale(typedLocale);
   const t = await getTranslations({ locale: typedLocale, namespace: 'auth' });
+  const tBrand = await getTranslations({
+    locale: typedLocale,
+    namespace: 'brand',
+  });
 
   return (
-    <main className="mx-auto flex min-h-[calc(100dvh-4rem)] max-w-md flex-col justify-center px-4 py-16">
-      <header className="mb-8">
-        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
-          {t('login.eyebrow')}
-        </p>
-        <h1 className="mt-2 font-display text-4xl leading-tight text-foreground">
-          {t('login.title')}
-        </h1>
-        <p className="mt-3 text-sm text-muted-foreground">{t('login.lede')}</p>
-      </header>
+    <main className="grid min-h-dvh grid-cols-1 lg:grid-cols-[1fr_minmax(420px,520px)]">
+      {/* COLONNE GAUCHE — éditoriale brutaliste */}
+      <aside className="relative hidden flex-col justify-between bg-foreground p-12 text-background lg:flex">
+        <header className="flex items-center justify-between">
+          <Link
+            href={`/${typedLocale}`}
+            className="font-mono text-xs uppercase tracking-[0.3em] text-background/70 transition hover:text-background"
+          >
+            ← {tBrand('name')}
+          </Link>
+          <span className="font-mono text-xs uppercase tracking-[0.3em] text-background/50">
+            {t('login.eyebrow')}
+          </span>
+        </header>
 
-      <LoginForm />
+        <div className="flex flex-col gap-6">
+          <p className="font-mono text-xs uppercase tracking-[0.3em] text-[oklch(0.85_0.20_120)]">
+            {t('login.editorialKicker')}
+          </p>
+          <h2 className="font-display text-5xl leading-[1.05] tracking-tight xl:text-6xl">
+            {t('login.editorialQuote')}
+          </h2>
+          <p className="max-w-md text-base leading-relaxed text-background/70">
+            {t('login.editorialAttribution')}
+          </p>
+        </div>
+
+        <footer className="flex items-center justify-between font-mono text-xs uppercase tracking-widest text-background/50">
+          <span>© IronTrack 2026</span>
+          <span>v2.0.0-alpha</span>
+        </footer>
+      </aside>
+
+      {/* COLONNE DROITE — formulaire */}
+      <section className="flex flex-col justify-center bg-background px-6 py-12 lg:px-12">
+        <div className="mx-auto w-full max-w-sm">
+          {/* Brand mobile only */}
+          <Link
+            href={`/${typedLocale}`}
+            className="mb-12 inline-flex items-center font-mono text-xs uppercase tracking-[0.3em] text-foreground lg:hidden"
+          >
+            ← {tBrand('name')}
+          </Link>
+
+          <header className="mb-10">
+            <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+              {t('login.eyebrow')}
+            </p>
+            <h1 className="mt-3 font-display text-4xl leading-[1.05] tracking-tight text-foreground sm:text-5xl">
+              {t('login.title')}
+            </h1>
+            <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+              {t('login.lede')}
+            </p>
+          </header>
+
+          <Suspense
+            fallback={<div className="h-[420px]" aria-hidden="true" />}
+          >
+            <LoginForm />
+          </Suspense>
+
+          <p className="mt-10 text-xs text-muted-foreground">
+            {t('login.terms')}{' '}
+            <Link
+              href={`/${typedLocale}/legal/privacy`}
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              {t('login.privacy')}
+            </Link>{' '}
+            ·{' '}
+            <Link
+              href={`/${typedLocale}/legal/terms`}
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              {t('login.termsLink')}
+            </Link>
+          </p>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/components/icons/google.tsx
+++ b/src/components/icons/google.tsx
@@ -1,0 +1,31 @@
+/**
+ * Logo Google officiel — utilisé pour le bouton "Continuer avec Google".
+ * Conforme aux brand guidelines Google Identity.
+ */
+export function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+    >
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.1c-.22-.66-.35-1.36-.35-2.1s.13-1.44.35-2.1V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.61z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z"
+      />
+    </svg>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -74,9 +74,19 @@
     "login": {
       "metaTitle": "Sign in · IronTrack",
       "metaDescription": "Sign in to IronTrack with a magic link. No password required.",
-      "eyebrow": "ACCESS · MAGIC LINK",
-      "title": "Sign in.",
-      "lede": "No password. We email you a secure link."
+      "eyebrow": "ACCESS · IRONTRACK",
+      "title": "Welcome back.",
+      "lede": "Sign in with Google or get a magic link by email. No password to remember.",
+      "editorialKicker": "MANIFESTO · 01",
+      "editorialQuote": "\"The iron never lies. Neither do your numbers.\"",
+      "editorialAttribution": "A fitness app built like a workshop notebook. No empty gamification, no anxiety-driven notifications. Just your data, your progress, your routine.",
+      "terms": "By continuing, you accept our",
+      "privacy": "Privacy policy",
+      "termsLink": "Terms of service"
+    },
+    "oauth": {
+      "google": "Continue with Google",
+      "or": "OR BY EMAIL"
     },
     "form": {
       "email": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -74,9 +74,19 @@
     "login": {
       "metaTitle": "Connexion · IronTrack",
       "metaDescription": "Connecte-toi à IronTrack avec un lien magique. Aucun mot de passe.",
-      "eyebrow": "ACCÈS · MAGIC LINK",
-      "title": "Connecte-toi.",
-      "lede": "Pas de mot de passe. On t'envoie un lien sécurisé par email."
+      "eyebrow": "ACCÈS · IRONTRACK",
+      "title": "Bon retour.",
+      "lede": "Connecte-toi avec Google ou reçois un lien magique par email. Pas de mot de passe à retenir.",
+      "editorialKicker": "MANIFESTE · 01",
+      "editorialQuote": "« L'iron ne ment jamais. Tes chiffres non plus. »",
+      "editorialAttribution": "Une app fitness pensée comme un carnet d'atelier. Pas de gamification creuse, pas de notifications anxiogènes. Juste tes données, tes progrès, ta routine.",
+      "terms": "En continuant, tu acceptes notre",
+      "privacy": "Politique de confidentialité",
+      "termsLink": "Conditions d'utilisation"
+    },
+    "oauth": {
+      "google": "Continuer avec Google",
+      "or": "OU PAR EMAIL"
     },
     "form": {
       "email": {

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -74,9 +74,19 @@
     "login": {
       "metaTitle": "Aanmelden · IronTrack",
       "metaDescription": "Meld je aan bij IronTrack met een magic link. Geen wachtwoord nodig.",
-      "eyebrow": "TOEGANG · MAGIC LINK",
-      "title": "Meld je aan.",
-      "lede": "Geen wachtwoord. We sturen je een beveiligde link per e-mail."
+      "eyebrow": "TOEGANG · IRONTRACK",
+      "title": "Welkom terug.",
+      "lede": "Meld je aan met Google of ontvang een magic link per e-mail. Geen wachtwoord nodig.",
+      "editorialKicker": "MANIFEST · 01",
+      "editorialQuote": "« IJzer liegt nooit. Je cijfers ook niet. »",
+      "editorialAttribution": "Een fitness-app als een atelierboek. Geen holle gamification, geen stresserende meldingen. Enkel je data, je vooruitgang, je routine.",
+      "terms": "Door verder te gaan, aanvaard je ons",
+      "privacy": "Privacybeleid",
+      "termsLink": "Gebruiksvoorwaarden"
+    },
+    "oauth": {
+      "google": "Doorgaan met Google",
+      "or": "OF MET E-MAIL"
     },
     "form": {
       "email": {


### PR DESCRIPTION
## Stack sur PR #38 (auth)

## Summary
- **Google OAuth** via Server Action `signInWithGoogle` (PKCE, rate-limit 10/60s)
- **Bouton officiel Google** + magic link email en dessous (séparateur \"OU PAR EMAIL\")
- **Layout split éditorial** : colonne gauche manifeste brutaliste fond noir + colonne droite formulaire
- **Touch targets 48px**, borders 2px brutalistes, tracking éditorial
- **useSearchParams** wrappé en Suspense (Next 16 prerender requirement)
- **Liens privacy / terms** (pages à créer en PR future)
- **Supabase config** : Site URL + uri_allow_list wildcards Vercel previews patchés via Management API

## Sécurité
- Rate-limit dédié OAuth (clé `oauth:`)
- Anti open-redirect sur `?next=` propagé jusqu'au callback
- `redirectTo` validé contre la redirect-allow-list Supabase
- noindex conservé

## Quality gates
- ✅ typecheck · lint · build (16 routes)

## Test plan
- [ ] Bouton Google → consent screen Google → retour app
- [ ] Magic link email toujours OK
- [ ] Layout split visible en desktop, formulaire seul en mobile
- [ ] FR/NL/EN cohérents
- [ ] `/login?next=/fr/dashboard` → après auth, redirige bien vers `/fr/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajouter la connexion via Google OAuth en complément du flux de lien magique existant et introduire une nouvelle mise en page éditoriale scindée pour la page de connexion.

Nouvelles fonctionnalités :
- Introduire une action serveur de connexion Google OAuth avec limitation de débit et gestion sécurisée des redirections.
- Ajouter un bouton de connexion officiel à la marque Google avec prise en charge de la redirection via le paramètre de requête `next` sur le formulaire de connexion.
- Implémenter une mise en page de connexion éditoriale scindée avec une colonne manifeste sombre à gauche et le formulaire à droite, incluant des liens légaux pour la confidentialité et les conditions d’utilisation.

Améliorations :
- Affiner la typographie, les espacements et les zones tactiles du formulaire de connexion pour répondre aux directives éditoriales et d’accessibilité.
- Envelopper le formulaire de connexion dans un Suspense afin de satisfaire les exigences de pré-rendu de Next.js et de fournir un fallback stable en termes de mise en page.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Google OAuth login alongside existing magic link flow and introduce a new split editorial layout for the login page.

New Features:
- Introduce a Google OAuth login server action with rate limiting and safe redirect handling.
- Add an official Google-branded sign-in button with support for `next` query redirection on the login form.
- Implement a split editorial login layout with a dark left manifesto column and right-side form, including legal links for privacy and terms.

Enhancements:
- Refine login form typography, spacing, and touch target sizes to meet editorial and accessibility guidelines.
- Wrap the login form in Suspense to satisfy Next.js prerendering requirements and provide a layout-stable fallback.

</details>