### PR TITLE
fix: home reflète l'état d'auth + /dashboard placeholder + logout

### DIFF
--- a/src/app/[locale]/actions.ts
+++ b/src/app/[locale]/actions.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+
+import { DEFAULT_LOCALE, type Locale } from '@/i18n/request';
+import { createServerClient } from '@/lib/supabase';
+
+/**
+ * Server Action : déconnexion + redirect vers la home locale.
+ */
+export async function signOut(formData: FormData): Promise<void> {
+  const locale = (formData.get('locale') as Locale) ?? DEFAULT_LOCALE;
+  const supabase = await createServerClient();
+  await supabase.auth.signOut();
+  redirect(`/${locale}`);
+}

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+import { requireUser } from '@/lib/auth';
+
+import { signOut } from '../actions';
+
+interface DashboardPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export const metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default async function DashboardPage({ params }: DashboardPageProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+  const user = await requireUser(typedLocale);
+  const t = await getTranslations({
+    locale: typedLocale,
+    namespace: 'dashboard',
+  });
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-16">
+      <header className="mb-12 flex items-start justify-between gap-4">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+            {t('eyebrow')}
+          </p>
+          <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
+            {t('title')}
+          </h1>
+          <p className="mt-3 text-base text-muted-foreground">
+            {t('greeting', { email: user.email ?? '' })}
+          </p>
+        </div>
+        <form action={signOut}>
+          <input type="hidden" name="locale" value={typedLocale} />
+          <button
+            type="submit"
+            className="min-h-[44px] border border-border px-4 py-2 font-mono text-xs uppercase tracking-widest text-foreground transition hover:bg-muted"
+          >
+            {t('logout')}
+          </button>
+        </form>
+      </header>
+
+      <section className="border-2 border-foreground p-8">
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('placeholder.label')}
+        </p>
+        <p className="mt-3 font-display text-2xl leading-snug text-foreground">
+          {t('placeholder.body')}
+        </p>
+        <Link
+          href={`/${typedLocale}`}
+          className="mt-6 inline-flex font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+        >
+          ← {t('back')}
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,6 +3,9 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LangSwitcher } from '@/components/lang-switcher';
 import { LOCALES, type Locale } from '@/i18n/request';
+import { getUser } from '@/lib/auth';
+
+import { signOut } from './actions';
 
 type HomePageProps = {
   params: Promise<{ locale: string }>;
@@ -17,6 +20,7 @@ export default async function HomePage({ params }: HomePageProps) {
 
   const t = await getTranslations('index');
   const tHome = await getTranslations('home');
+  const user = await getUser();
 
   return (
     <main className="mx-auto max-w-7xl px-8 pb-40 pt-16">
@@ -27,7 +31,29 @@ export default async function HomePage({ params }: HomePageProps) {
         <span className="eyebrow inline-flex items-center">
           <BrandDot /> {t('eyebrow')}
         </span>
-        <LangSwitcher />
+        <div className="flex items-center gap-4">
+          {user && (
+            <div className="hidden items-center gap-3 sm:flex">
+              <span
+                className="font-mono text-xs uppercase tracking-widest"
+                style={{ color: 'var(--color-muted-foreground)' }}
+              >
+                {user.email}
+              </span>
+              <form action={signOut}>
+                <input type="hidden" name="locale" value={typedLocale} />
+                <button
+                  type="submit"
+                  className="font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+                  style={{ color: 'var(--color-foreground)' }}
+                >
+                  {tHome('cta.logout')}
+                </button>
+              </form>
+            </div>
+          )}
+          <LangSwitcher />
+        </div>
       </header>
 
       <section
@@ -127,27 +153,54 @@ export default async function HomePage({ params }: HomePageProps) {
         </div>
 
         <div className="mt-12 flex flex-wrap items-center gap-4">
-          <Link
-            href={`/${typedLocale}/login`}
-            className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
-            style={{
-              background: 'var(--color-brand)',
-              color: 'var(--color-primary-foreground)',
-              boxShadow: 'var(--shadow-glow)',
-            }}
-          >
-            {tHome('cta.start')}
-            <span className="transition-transform group-hover:translate-x-0.5">
-              →
-            </span>
-          </Link>
-          <Link
-            href={`/${typedLocale}/login`}
-            className="inline-flex min-h-12 items-center gap-2 rounded-full border px-6 py-3 font-semibold transition-colors hover:bg-[var(--color-muted)]"
-            style={{ borderColor: 'var(--color-border)' }}
-          >
-            {tHome('cta.login')}
-          </Link>
+          {user ? (
+            <>
+              <span
+                className="eyebrow"
+                style={{ color: 'var(--color-muted-foreground)' }}
+              >
+                {tHome('greeting', { email: user.email ?? '' })}
+              </span>
+              <Link
+                href={`/${typedLocale}/dashboard`}
+                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+                style={{
+                  background: 'var(--color-brand)',
+                  color: 'var(--color-primary-foreground)',
+                  boxShadow: 'var(--shadow-glow)',
+                }}
+              >
+                {tHome('cta.dashboard')}
+                <span className="transition-transform group-hover:translate-x-0.5">
+                  →
+                </span>
+              </Link>
+            </>
+          ) : (
+            <>
+              <Link
+                href={`/${typedLocale}/login`}
+                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+                style={{
+                  background: 'var(--color-brand)',
+                  color: 'var(--color-primary-foreground)',
+                  boxShadow: 'var(--shadow-glow)',
+                }}
+              >
+                {tHome('cta.start')}
+                <span className="transition-transform group-hover:translate-x-0.5">
+                  →
+                </span>
+              </Link>
+              <Link
+                href={`/${typedLocale}/login`}
+                className="inline-flex min-h-12 items-center gap-2 rounded-full border px-6 py-3 font-semibold transition-colors hover:bg-[var(--color-muted)]"
+                style={{ borderColor: 'var(--color-border)' }}
+              >
+                {tHome('cta.login')}
+              </Link>
+            </>
+          )}
         </div>
       </section>
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -62,7 +62,24 @@
       "lighter": "lighter.",
       "lede": "A fitness app built like a workshop notebook: precise, editorial, brutalist. No confetti. No jargon. Just your body, your numbers, your progress."
     },
-    "cta": { "start": "Start the session", "login": "Sign in" }
+    "cta": {
+      "start": "Start the session",
+      "login": "Sign in",
+      "dashboard": "My dashboard",
+      "logout": "Sign out"
+    },
+    "greeting": "Signed in as {email}"
+  },
+  "dashboard": {
+    "eyebrow": "DASHBOARD",
+    "title": "Welcome.",
+    "greeting": "Signed in as {email}.",
+    "logout": "Sign out",
+    "back": "Back to home",
+    "placeholder": {
+      "label": "COMING NEXT",
+      "body": "The real dashboard is on its way: your last session, your records, your upcoming sessions, your progress graphs."
+    }
   },
   "langSwitcher": {
     "label": "Choose language",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -62,7 +62,24 @@
       "lighter": "lighter.",
       "lede": "Une app fitness pensée comme un carnet d'atelier : précise, éditoriale, brutaliste. Pas de confettis. Pas de jargon. Juste ton corps, tes chiffres, ton progrès."
     },
-    "cta": { "start": "Commencer la séance", "login": "Se connecter" }
+    "cta": {
+      "start": "Commencer la séance",
+      "login": "Se connecter",
+      "dashboard": "Mon tableau de bord",
+      "logout": "Se déconnecter"
+    },
+    "greeting": "Connecté en tant que {email}"
+  },
+  "dashboard": {
+    "eyebrow": "TABLEAU DE BORD",
+    "title": "Bienvenue.",
+    "greeting": "Connecté en tant que {email}.",
+    "logout": "Se déconnecter",
+    "back": "Retour à l'accueil",
+    "placeholder": {
+      "label": "PROCHAINE ÉTAPE",
+      "body": "Le vrai tableau de bord arrive : ta dernière séance, tes records, tes prochaines sessions, tes graphes de progression."
+    }
   },
   "langSwitcher": {
     "label": "Choisir la langue",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -62,7 +62,24 @@
       "lighter": "lichter.",
       "lede": "Een fitness-app gebouwd als een atelierboek: precies, redactioneel, brutalistisch. Geen confetti. Geen jargon. Enkel jouw lichaam, jouw cijfers, jouw vooruitgang."
     },
-    "cta": { "start": "Sessie starten", "login": "Aanmelden" }
+    "cta": {
+      "start": "Sessie starten",
+      "login": "Aanmelden",
+      "dashboard": "Mijn dashboard",
+      "logout": "Afmelden"
+    },
+    "greeting": "Aangemeld als {email}"
+  },
+  "dashboard": {
+    "eyebrow": "DASHBOARD",
+    "title": "Welkom.",
+    "greeting": "Aangemeld als {email}.",
+    "logout": "Afmelden",
+    "back": "Terug naar start",
+    "placeholder": {
+      "label": "VOLGENDE STAP",
+      "body": "Het echte dashboard komt eraan: je laatste sessie, je records, je volgende sessies, je voortgangsgrafieken."
+    }
   },
   "langSwitcher": {
     "label": "Taal kiezen",


### PR DESCRIPTION
## Stack sur PR #39

## Bug fix
La home actuelle affiche \"Se connecter\" en dur même quand l'utilisateur EST connecté → confusion totale après auth réussie.

## Changements
- **Home** : `getUser()` côté serveur → si connecté, affiche email + bouton \"Mon tableau de bord\". Sinon CTAs login.
- **Bouton logout** dans le header (>sm) avec server action `signOut`
- **Page `/dashboard`** placeholder, protégée par `requireUser()` (redirect login si invité)
- **Traductions** FR/NL/EN pour greeting / dashboard / logout

## Test plan
- [ ] Non connecté → home montre \"Commencer la séance\" + \"Se connecter\"
- [ ] Connecté → home montre email + \"Mon tableau de bord\" + bouton logout
- [ ] `/fr/dashboard` connecté → page placeholder
- [ ] `/fr/dashboard` non connecté → redirect `/fr/login?next=/fr/dashboard`
- [ ] Bouton logout → retour home non connecté

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Met à jour la page d’accueil pour refléter l’état d’authentification, introduit un espace réservé pour un tableau de bord protégé, et ajoute des parcours de déconnexion localisés.

Nouvelles fonctionnalités :
- Ajoute une page de tableau de bord authentifiée et localisée, protégée par un accès réservé aux utilisateurs.

Corrections de bugs :
- Corrige le CTA de la page d’accueil afin qu’il n’affiche plus systématiquement les invites de connexion lorsque l’utilisateur est déjà authentifié.

Améliorations :
- Affiche l’email de l’utilisateur authentifié et un CTA vers le tableau de bord sur la page d’accueil lorsque l’utilisateur est connecté, et affiche un contrôle de déconnexion dans l’en-tête sur les grands écrans.
- Met en œuvre une action de déconnexion partagée côté serveur qui déconnecte l’utilisateur et le redirige vers la page d’accueil appropriée en fonction de la langue/localisation.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the home page to reflect authentication state, introduce a protected dashboard placeholder, and add localized logout flows.

New Features:
- Add a localized, authenticated dashboard page protected by user-required access.

Bug Fixes:
- Fix the home page CTA so it no longer always shows login prompts when the user is already authenticated.

Enhancements:
- Show the authenticated user’s email and a dashboard CTA on the home page when logged in, and display a logout control in the header on larger screens.
- Implement a shared server-side logout action that signs the user out and redirects to the appropriate locale-specific home page.

</details>