### PR TITLE
feat(home): editorial redesign + cross-tab auth sync

### DIFF
--- a/src/app/[locale]/_home/features.tsx
+++ b/src/app/[locale]/_home/features.tsx
@@ -1,0 +1,96 @@
+import { useTranslations } from 'next-intl';
+import { Activity, BarChart3, Apple, Sparkles } from 'lucide-react';
+
+const FEATURE_KEYS = ['logging', 'progress', 'nutrition', 'coach'] as const;
+
+const ICONS = {
+  logging: Activity,
+  progress: BarChart3,
+  nutrition: Apple,
+  coach: Sparkles,
+} as const;
+
+const ACCENTS = {
+  logging: 'var(--color-brand)',
+  progress: 'var(--color-acid)',
+  nutrition: 'var(--color-azure)',
+  coach: 'var(--color-amber)',
+} as const;
+
+export function HomeFeatures() {
+  const t = useTranslations('home.features');
+
+  return (
+    <section id="features" className="mt-32">
+      <header
+        className="flex items-end justify-between gap-6 border-b pb-3"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <h2 className="display text-4xl md:text-5xl">
+          {t('heading')}{' '}
+          <em
+            className="display-italic"
+            style={{ color: 'var(--color-brand)' }}
+          >
+            {t('headingAccent')}
+          </em>
+        </h2>
+        <span className="eyebrow hidden md:inline">{t('eyebrow')}</span>
+      </header>
+
+      <div className="mt-12 grid gap-px bg-[var(--color-border)] md:grid-cols-2">
+        {FEATURE_KEYS.map((key) => {
+          const Icon = ICONS[key];
+          return (
+            <article
+              key={key}
+              className="group relative flex flex-col gap-5 p-8 transition-colors md:p-10"
+              style={{ background: 'var(--color-background)' }}
+            >
+              <div className="flex items-start justify-between">
+                <span
+                  className="flex size-12 items-center justify-center rounded-xs"
+                  style={{ background: ACCENTS[key], color: 'var(--color-ink)' }}
+                  aria-hidden
+                >
+                  <Icon className="size-6" strokeWidth={2.2} />
+                </span>
+                <span
+                  className="font-mono text-[11px] uppercase tracking-[0.2em]"
+                  style={{ color: 'var(--color-muted-foreground)' }}
+                >
+                  {t(`${key}.tag`)}
+                </span>
+              </div>
+
+              <h3 className="display text-3xl leading-tight">
+                {t(`${key}.title`)}
+              </h3>
+              <p
+                className="text-base leading-relaxed"
+                style={{ color: 'var(--color-muted-foreground)' }}
+              >
+                {t(`${key}.body`)}
+              </p>
+
+              <ul
+                className="mt-2 flex flex-wrap gap-2 font-mono text-[11px] uppercase tracking-widest"
+                style={{ color: 'var(--color-muted-foreground)' }}
+              >
+                {[1, 2, 3].map((i) => (
+                  <li
+                    key={i}
+                    className="rounded-full border px-3 py-1"
+                    style={{ borderColor: 'var(--color-border)' }}
+                  >
+                    {t(`${key}.bullet${i}`)}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/app/[locale]/_home/hero.tsx
+++ b/src/app/[locale]/_home/hero.tsx
@@ -1,0 +1,106 @@
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+import type { Locale } from '@/i18n/request';
+
+interface HeroProps {
+  locale: Locale;
+  isAuthenticated: boolean;
+  userEmail?: string | null;
+}
+
+export function HomeHero({ locale, isAuthenticated, userEmail }: HeroProps) {
+  const t = useTranslations('home.hero');
+
+  return (
+    <section
+      className="rise grid items-end gap-12 border-b pb-16 md:grid-cols-[1.2fr_1fr]"
+      style={{ borderColor: 'var(--color-border)', animationDelay: '0.15s' }}
+    >
+      <div>
+        <span className="eyebrow">{t('kicker')}</span>
+        <h1 className="display mt-6 text-[clamp(56px,10vw,128px)] leading-[0.95]">
+          {t('train')}{' '}
+          <span
+            className="display-italic"
+            style={{ color: 'var(--color-brand)' }}
+          >
+            {t('heavier')}
+          </span>
+          <br />
+          <span className="relative inline-block">
+            <span className="relative z-10">{t('live')}</span>
+            <span
+              aria-hidden
+              className="absolute bottom-[0.08em] left-0 right-0 h-3 -skew-x-[8deg]"
+              style={{ background: 'var(--color-acid)', zIndex: -1 }}
+            />
+          </span>{' '}
+          {t('lighter')}
+        </h1>
+        <div className="mt-10 flex flex-wrap items-center gap-4">
+          {isAuthenticated ? (
+            <>
+              <Link
+                href={`/${locale}/dashboard`}
+                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-7 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+                style={{
+                  background: 'var(--color-brand)',
+                  color: 'var(--color-primary-foreground)',
+                  boxShadow: 'var(--shadow-glow)',
+                }}
+              >
+                {t('cta.dashboard')}
+                <span className="transition-transform group-hover:translate-x-0.5">
+                  →
+                </span>
+              </Link>
+              {userEmail && (
+                <span
+                  className="font-mono text-xs uppercase tracking-widest"
+                  style={{ color: 'var(--color-muted-foreground)' }}
+                >
+                  · {userEmail}
+                </span>
+              )}
+            </>
+          ) : (
+            <>
+              <Link
+                href={`/${locale}/login`}
+                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-7 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+                style={{
+                  background: 'var(--color-brand)',
+                  color: 'var(--color-primary-foreground)',
+                  boxShadow: 'var(--shadow-glow)',
+                }}
+              >
+                {t('cta.start')}
+                <span className="transition-transform group-hover:translate-x-0.5">
+                  →
+                </span>
+              </Link>
+              <Link
+                href="#features"
+                className="inline-flex min-h-12 items-center gap-2 rounded-full border px-6 py-3 font-semibold transition-colors hover:bg-[var(--color-muted)]"
+                style={{ borderColor: 'var(--color-border)' }}
+              >
+                {t('cta.discover')}
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+
+      <p
+        className="display-italic text-xl leading-snug md:max-w-md"
+        style={{
+          color:
+            'color-mix(in oklab, var(--color-foreground) 80%, transparent)',
+        }}
+      >
+        {t('lede')}
+      </p>
+    </section>
+  );
+}

--- a/src/app/[locale]/_home/how.tsx
+++ b/src/app/[locale]/_home/how.tsx
@@ -1,0 +1,46 @@
+import { useTranslations } from 'next-intl';
+
+const STEPS = ['log', 'track', 'progress'] as const;
+
+export function HomeHow() {
+  const t = useTranslations('home.how');
+
+  return (
+    <section className="mt-32">
+      <header
+        className="flex items-end justify-between gap-6 border-b pb-3"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <h2 className="display text-4xl md:text-5xl">{t('heading')}</h2>
+        <span className="eyebrow hidden md:inline">{t('eyebrow')}</span>
+      </header>
+
+      <ol className="mt-12 grid gap-10 md:grid-cols-3 md:gap-16">
+        {STEPS.map((step, i) => (
+          <li key={step} className="flex flex-col gap-4">
+            <span
+              className="display text-[120px] leading-none"
+              style={{
+                color:
+                  'color-mix(in oklab, var(--color-brand) 100%, transparent)',
+                opacity: 0.85,
+              }}
+              aria-hidden
+            >
+              {String(i + 1).padStart(2, '0')}
+            </span>
+            <h3 className="display text-2xl leading-tight">
+              {t(`${step}.title`)}
+            </h3>
+            <p
+              className="text-base leading-relaxed"
+              style={{ color: 'var(--color-muted-foreground)' }}
+            >
+              {t(`${step}.body`)}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/app/[locale]/_home/manifesto.tsx
+++ b/src/app/[locale]/_home/manifesto.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+import type { Locale } from '@/i18n/request';
+
+interface ManifestoProps {
+  locale: Locale;
+  isAuthenticated: boolean;
+}
+
+export function HomeManifesto({ locale, isAuthenticated }: ManifestoProps) {
+  const t = useTranslations('home.manifesto');
+
+  return (
+    <section
+      className="mt-32 -mx-8 px-8 py-24 md:px-16 md:py-32"
+      style={{
+        background: 'var(--color-foreground)',
+        color: 'var(--color-background)',
+      }}
+    >
+      <div className="mx-auto max-w-4xl">
+        <p
+          className="font-mono text-xs uppercase tracking-[0.3em]"
+          style={{ color: 'var(--color-acid)' }}
+        >
+          {t('eyebrow')}
+        </p>
+        <blockquote className="display mt-8 text-[clamp(40px,6vw,72px)] leading-[1.05]">
+          {t('quote')}
+        </blockquote>
+        <p
+          className="mt-8 max-w-2xl text-base leading-relaxed"
+          style={{
+            color:
+              'color-mix(in oklab, var(--color-background) 75%, transparent)',
+          }}
+        >
+          {t('body')}
+        </p>
+
+        <div className="mt-12">
+          <Link
+            href={isAuthenticated ? `/${locale}/dashboard` : `/${locale}/login`}
+            className="group inline-flex min-h-12 items-center gap-2 rounded-full px-7 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+            style={{
+              background: 'var(--color-brand)',
+              color: 'var(--color-primary-foreground)',
+              boxShadow: 'var(--shadow-glow)',
+            }}
+          >
+            {t(isAuthenticated ? 'cta.dashboard' : 'cta.start')}
+            <span className="transition-transform group-hover:translate-x-0.5">
+              →
+            </span>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/[locale]/_home/vs.tsx
+++ b/src/app/[locale]/_home/vs.tsx
@@ -1,0 +1,128 @@
+import { useTranslations } from 'next-intl';
+
+const ROWS = [
+  { key: 'logging', us: true, hevy: true, strava: false, whoop: false },
+  { key: 'cardio', us: true, hevy: false, strava: true, whoop: true },
+  { key: 'nutrition', us: true, hevy: false, strava: false, whoop: false },
+  { key: 'belgian', us: true, hevy: false, strava: false, whoop: false },
+  { key: 'noads', us: true, hevy: false, strava: false, whoop: true },
+  { key: 'opensource', us: true, hevy: false, strava: false, whoop: false },
+] as const;
+
+function Cell({ on }: { on: boolean }) {
+  return (
+    <span
+      className="inline-flex size-7 items-center justify-center rounded-full font-mono text-sm"
+      style={{
+        background: on ? 'var(--color-acid)' : 'transparent',
+        color: on ? 'var(--color-ink)' : 'var(--color-muted-foreground)',
+        border: on ? 'none' : '1px solid var(--color-border)',
+      }}
+      aria-label={on ? 'oui' : 'non'}
+    >
+      {on ? '●' : '·'}
+    </span>
+  );
+}
+
+export function HomeVs() {
+  const t = useTranslations('home.vs');
+
+  return (
+    <section className="mt-32">
+      <header
+        className="flex items-end justify-between gap-6 border-b pb-3"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <h2 className="display text-4xl md:text-5xl">
+          {t('heading')}{' '}
+          <em
+            className="display-italic"
+            style={{ color: 'var(--color-brand)' }}
+          >
+            {t('headingAccent')}
+          </em>
+        </h2>
+        <span className="eyebrow hidden md:inline">{t('eyebrow')}</span>
+      </header>
+
+      <p
+        className="display-italic mt-8 max-w-2xl text-xl leading-snug"
+        style={{
+          color:
+            'color-mix(in oklab, var(--color-foreground) 80%, transparent)',
+        }}
+      >
+        {t('lede')}
+      </p>
+
+      <div className="mt-12 overflow-x-auto">
+        <table
+          className="w-full min-w-[640px] border-collapse text-left"
+          style={{ borderColor: 'var(--color-border)' }}
+        >
+          <thead>
+            <tr
+              className="font-mono text-[11px] uppercase tracking-widest"
+              style={{ color: 'var(--color-muted-foreground)' }}
+            >
+              <th className="border-b py-4 pr-4 font-normal" style={{ borderColor: 'var(--color-border)' }}>
+                {t('feature')}
+              </th>
+              <th
+                className="border-b py-4 px-3 text-center font-bold"
+                style={{
+                  borderColor: 'var(--color-border)',
+                  color: 'var(--color-brand)',
+                }}
+              >
+                IronTrack
+              </th>
+              <th className="border-b py-4 px-3 text-center font-normal" style={{ borderColor: 'var(--color-border)' }}>
+                Hevy
+              </th>
+              <th className="border-b py-4 px-3 text-center font-normal" style={{ borderColor: 'var(--color-border)' }}>
+                Strava
+              </th>
+              <th className="border-b py-4 px-3 text-center font-normal" style={{ borderColor: 'var(--color-border)' }}>
+                Whoop
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map((row) => (
+              <tr
+                key={row.key}
+                className="border-b text-sm"
+                style={{ borderColor: 'var(--color-border)' }}
+              >
+                <td className="py-4 pr-4 font-medium">
+                  {t(`rows.${row.key}`)}
+                </td>
+                <td className="px-3 py-4 text-center">
+                  <Cell on={row.us} />
+                </td>
+                <td className="px-3 py-4 text-center">
+                  <Cell on={row.hevy} />
+                </td>
+                <td className="px-3 py-4 text-center">
+                  <Cell on={row.strava} />
+                </td>
+                <td className="px-3 py-4 text-center">
+                  <Cell on={row.whoop} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p
+        className="mt-6 font-mono text-[11px] uppercase tracking-widest"
+        style={{ color: 'var(--color-muted-foreground)' }}
+      >
+        {t('disclaimer')}
+      </p>
+    </section>
+  );
+}

--- a/src/app/[locale]/login/actions.ts
+++ b/src/app/[locale]/login/actions.ts
@@ -3,17 +3,25 @@
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import { magicLinkSchema } from '@/lib/auth/schema';
+import { credentialsSchema, magicLinkSchema } from '@/lib/auth/schema';
 import { getClientIp, rateLimit } from '@/lib/rate-limit';
 import { createServerClient } from '@/lib/supabase';
 
+export type LoginErrorKey =
+  | 'auth.errors.emailRequired'
+  | 'auth.errors.emailInvalid'
+  | 'auth.errors.passwordTooShort'
+  | 'auth.errors.passwordTooLong'
+  | 'auth.errors.passwordWeak'
+  | 'auth.errors.invalidCredentials'
+  | 'auth.errors.emailTaken'
+  | 'auth.errors.rateLimit'
+  | 'auth.errors.generic';
+
 export interface LoginState {
   status: 'idle' | 'success' | 'error';
-  error?:
-    | 'auth.errors.emailRequired'
-    | 'auth.errors.emailInvalid'
-    | 'auth.errors.rateLimit'
-    | 'auth.errors.generic';
+  error?: LoginErrorKey;
+  field?: 'email' | 'password' | 'form';
 }
 
 /**
@@ -115,4 +123,114 @@ export async function signInWithGoogle(formData: FormData): Promise<void> {
   }
 
   redirect(data.url);
+}
+
+/**
+ * Server Action : sign-in classique email + password.
+ * Sécurité : rate-limit 10/min/IP, message générique en cas d'échec
+ * (pas d'enumération entre "mauvais mdp" et "user inexistant").
+ */
+export async function signInWithPassword(
+  _prev: LoginState,
+  formData: FormData,
+): Promise<LoginState> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`pwd-in:${ip}`, { limit: 10, windowMs: 60_000 });
+  if (!ok) {
+    return { status: 'error', error: 'auth.errors.rateLimit', field: 'form' };
+  }
+
+  const parsed = credentialsSchema.safeParse({
+    email: formData.get('email'),
+    password: formData.get('password'),
+  });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const msg = issue?.message as LoginErrorKey | undefined;
+    const field = (issue?.path[0] as 'email' | 'password' | undefined) ?? 'form';
+    return {
+      status: 'error',
+      error: msg ?? 'auth.errors.invalidCredentials',
+      field,
+    };
+  }
+
+  const supabase = await createServerClient();
+  const { error } = await supabase.auth.signInWithPassword({
+    email: parsed.data.email,
+    password: parsed.data.password,
+  });
+
+  if (error) {
+    return {
+      status: 'error',
+      error: 'auth.errors.invalidCredentials',
+      field: 'form',
+    };
+  }
+
+  const next = formData.get('next');
+  const safeNext =
+    typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')
+      ? next
+      : '/';
+  redirect(safeNext);
+}
+
+/**
+ * Server Action : sign-up email + password.
+ * Avec mailer_autoconfirm=true côté Supabase, le user est connecté direct
+ * sans email de confirmation.
+ */
+export async function signUpWithPassword(
+  _prev: LoginState,
+  formData: FormData,
+): Promise<LoginState> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`pwd-up:${ip}`, { limit: 5, windowMs: 60_000 });
+  if (!ok) {
+    return { status: 'error', error: 'auth.errors.rateLimit', field: 'form' };
+  }
+
+  const parsed = credentialsSchema.safeParse({
+    email: formData.get('email'),
+    password: formData.get('password'),
+  });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const msg = issue?.message as LoginErrorKey | undefined;
+    const field = (issue?.path[0] as 'email' | 'password' | undefined) ?? 'form';
+    return {
+      status: 'error',
+      error: msg ?? 'auth.errors.passwordWeak',
+      field,
+    };
+  }
+
+  const supabase = await createServerClient();
+  const { error } = await supabase.auth.signUp({
+    email: parsed.data.email,
+    password: parsed.data.password,
+  });
+
+  if (error) {
+    // Supabase renvoie "User already registered" en clair → on map sur clé i18n.
+    const isTaken = /already|exists|registered/i.test(error.message);
+    return {
+      status: 'error',
+      error: isTaken ? 'auth.errors.emailTaken' : 'auth.errors.generic',
+      field: isTaken ? 'email' : 'form',
+    };
+  }
+
+  const next = formData.get('next');
+  const safeNext =
+    typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')
+      ? next
+      : '/';
+  redirect(safeNext);
 }

--- a/src/app/[locale]/login/login-form.tsx
+++ b/src/app/[locale]/login/login-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState, useEffect } from 'react';
+import { useActionState, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 
@@ -10,9 +10,18 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { createClient } from '@/lib/supabase/client';
 
-import { sendMagicLink, signInWithGoogle, type LoginState } from './actions';
+import {
+  sendMagicLink,
+  signInWithGoogle,
+  signInWithPassword,
+  signUpWithPassword,
+  type LoginState,
+} from './actions';
 
 const initial: LoginState = { status: 'idle' };
+
+type Tab = 'password' | 'magic';
+type Mode = 'signin' | 'signup';
 
 export function LoginForm() {
   const t = useTranslations('auth');
@@ -20,15 +29,27 @@ export function LoginForm() {
   const locale = useLocale();
   const searchParams = useSearchParams();
   const next = searchParams.get('next') ?? '/';
-  const [state, action, pending] = useActionState(sendMagicLink, initial);
 
-  // Cross-tab auth: si l'utilisateur clique le magic link dans un nouvel onglet,
-  // Supabase synchronise la session via BroadcastChannel — on redirige cet onglet aussi.
+  const [tab, setTab] = useState<Tab>('password');
+  const [mode, setMode] = useState<Mode>('signin');
+
+  const [magicState, magicAction, magicPending] = useActionState(
+    sendMagicLink,
+    initial,
+  );
+  const [pwdState, pwdAction, pwdPending] = useActionState(
+    mode === 'signin' ? signInWithPassword : signUpWithPassword,
+    initial,
+  );
+
+  // Cross-tab auth : si le user clique le magic link dans un autre onglet,
+  // BroadcastChannel synchronise la session — on redirige cet onglet aussi.
   useEffect(() => {
     const supabase = createClient();
     const { data } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === 'SIGNED_IN' && session) {
-        const safeNext = next.startsWith('/') && !next.startsWith('//') ? next : '/';
+        const safeNext =
+          next.startsWith('/') && !next.startsWith('//') ? next : '/';
         const target = safeNext === '/' ? `/${locale}/dashboard` : safeNext;
         router.replace(target);
         router.refresh();
@@ -37,7 +58,7 @@ export function LoginForm() {
     return () => data.subscription.unsubscribe();
   }, [router, locale, next]);
 
-  if (state.status === 'success') {
+  if (magicState.status === 'success') {
     return (
       <div
         role="status"
@@ -81,47 +102,198 @@ export function LoginForm() {
         <span className="h-px flex-1 bg-border" />
       </div>
 
-      {/* Magic link email */}
-      <form action={action} noValidate className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="email" className="font-mono text-xs uppercase tracking-widest">
-            {t('form.email.label')}
-          </Label>
-          <Input
-            id="email"
-            name="email"
-            type="email"
-            autoComplete="email"
-            inputMode="email"
-            required
-            aria-invalid={state.status === 'error'}
-            aria-describedby={state.status === 'error' ? 'email-error' : undefined}
-            placeholder={t('form.email.placeholder')}
-            className="min-h-[48px] border-2 border-foreground text-base"
-          />
-          {state.status === 'error' && state.error && (
+      {/* Tabs : password / magic link */}
+      <div
+        role="tablist"
+        aria-label={t('tabs.label')}
+        className="grid grid-cols-2 border-2 border-foreground"
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'password'}
+          onClick={() => setTab('password')}
+          className="min-h-[44px] font-mono text-xs uppercase tracking-widest transition-colors"
+          style={{
+            background:
+              tab === 'password'
+                ? 'var(--color-foreground)'
+                : 'transparent',
+            color:
+              tab === 'password'
+                ? 'var(--color-background)'
+                : 'var(--color-foreground)',
+          }}
+        >
+          {t('tabs.password')}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'magic'}
+          onClick={() => setTab('magic')}
+          className="min-h-[44px] font-mono text-xs uppercase tracking-widest transition-colors"
+          style={{
+            background:
+              tab === 'magic' ? 'var(--color-foreground)' : 'transparent',
+            color:
+              tab === 'magic'
+                ? 'var(--color-background)'
+                : 'var(--color-foreground)',
+            borderLeft: '2px solid var(--color-foreground)',
+          }}
+        >
+          {t('tabs.magic')}
+        </button>
+      </div>
+
+      {tab === 'password' ? (
+        <form action={pwdAction} noValidate className="flex flex-col gap-4">
+          <input type="hidden" name="next" value={next} />
+
+          <div className="flex flex-col gap-2">
+            <Label
+              htmlFor="email"
+              className="font-mono text-xs uppercase tracking-widest"
+            >
+              {t('form.email.label')}
+            </Label>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              inputMode="email"
+              required
+              aria-invalid={
+                pwdState.status === 'error' && pwdState.field === 'email'
+              }
+              placeholder={t('form.email.placeholder')}
+              className="min-h-[48px] border-2 border-foreground text-base"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label
+              htmlFor="password"
+              className="font-mono text-xs uppercase tracking-widest"
+            >
+              {t('form.password.label')}
+            </Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete={
+                mode === 'signin' ? 'current-password' : 'new-password'
+              }
+              required
+              minLength={10}
+              aria-invalid={
+                pwdState.status === 'error' && pwdState.field === 'password'
+              }
+              aria-describedby="password-help"
+              placeholder={t('form.password.placeholder')}
+              className="min-h-[48px] border-2 border-foreground text-base"
+            />
             <p
-              id="email-error"
+              id="password-help"
+              className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground"
+            >
+              {t('form.password.help')}
+            </p>
+          </div>
+
+          {pwdState.status === 'error' && pwdState.error && (
+            <p
               role="alert"
               className="text-sm font-medium text-destructive"
             >
-              {t(state.error.replace('auth.', '') as 'errors.emailInvalid')}
+              {t(
+                pwdState.error.replace(
+                  'auth.',
+                  '',
+                ) as 'errors.invalidCredentials',
+              )}
             </p>
           )}
-        </div>
 
-        <Button
-          type="submit"
-          disabled={pending}
-          className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+          <Button
+            type="submit"
+            disabled={pwdPending}
+            className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+          >
+            {pwdPending
+              ? t('form.submitPending')
+              : mode === 'signin'
+                ? t('form.signin')
+                : t('form.signup')}
+          </Button>
+
+          <button
+            type="button"
+            onClick={() => setMode(mode === 'signin' ? 'signup' : 'signin')}
+            className="self-start font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+          >
+            {mode === 'signin' ? t('form.toSignup') : t('form.toSignin')}
+          </button>
+        </form>
+      ) : (
+        <form
+          action={magicAction}
+          noValidate
+          className="flex flex-col gap-4"
         >
-          {pending ? t('form.submitPending') : t('form.submit')}
-        </Button>
+          <div className="flex flex-col gap-2">
+            <Label
+              htmlFor="magic-email"
+              className="font-mono text-xs uppercase tracking-widest"
+            >
+              {t('form.email.label')}
+            </Label>
+            <Input
+              id="magic-email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              inputMode="email"
+              required
+              aria-invalid={magicState.status === 'error'}
+              aria-describedby={
+                magicState.status === 'error' ? 'magic-error' : undefined
+              }
+              placeholder={t('form.email.placeholder')}
+              className="min-h-[48px] border-2 border-foreground text-base"
+            />
+            {magicState.status === 'error' && magicState.error && (
+              <p
+                id="magic-error"
+                role="alert"
+                className="text-sm font-medium text-destructive"
+              >
+                {t(
+                  magicState.error.replace(
+                    'auth.',
+                    '',
+                  ) as 'errors.emailInvalid',
+                )}
+              </p>
+            )}
+          </div>
 
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          {t('form.hint')}
-        </p>
-      </form>
+          <Button
+            type="submit"
+            disabled={magicPending}
+            className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+          >
+            {magicPending ? t('form.submitPending') : t('form.submit')}
+          </Button>
+
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {t('form.hint')}
+          </p>
+        </form>
+      )}
     </div>
   );
 }

--- a/src/app/[locale]/login/login-form.tsx
+++ b/src/app/[locale]/login/login-form.tsx
@@ -11,7 +11,6 @@ import { Label } from '@/components/ui/label';
 import { createClient } from '@/lib/supabase/client';
 
 import {
-  sendMagicLink,
   signInWithGoogle,
   signInWithPassword,
   signUpWithPassword,
@@ -20,7 +19,6 @@ import {
 
 const initial: LoginState = { status: 'idle' };
 
-type Tab = 'password' | 'magic';
 type Mode = 'signin' | 'signup';
 
 export function LoginForm() {
@@ -30,20 +28,15 @@ export function LoginForm() {
   const searchParams = useSearchParams();
   const next = searchParams.get('next') ?? '/';
 
-  const [tab, setTab] = useState<Tab>('password');
   const [mode, setMode] = useState<Mode>('signin');
 
-  const [magicState, magicAction, magicPending] = useActionState(
-    sendMagicLink,
-    initial,
-  );
   const [pwdState, pwdAction, pwdPending] = useActionState(
     mode === 'signin' ? signInWithPassword : signUpWithPassword,
     initial,
   );
 
-  // Cross-tab auth : si le user clique le magic link dans un autre onglet,
-  // BroadcastChannel synchronise la session — on redirige cet onglet aussi.
+  // Sync cross-onglet : OAuth Google ouvre un onglet de redirect, on récupère
+  // la session ici dès qu'elle est posée et on redirige.
   useEffect(() => {
     const supabase = createClient();
     const { data } = supabase.auth.onAuthStateChange((event, session) => {
@@ -57,26 +50,6 @@ export function LoginForm() {
     });
     return () => data.subscription.unsubscribe();
   }, [router, locale, next]);
-
-  if (magicState.status === 'success') {
-    return (
-      <div
-        role="status"
-        aria-live="polite"
-        className="border-2 border-foreground bg-card p-6 text-foreground"
-      >
-        <h2 className="font-display text-2xl leading-tight">
-          {t('checkEmail.title')}
-        </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {t('checkEmail.body')}
-        </p>
-        <p className="mt-3 text-xs text-muted-foreground">
-          {t('checkEmail.hint')}
-        </p>
-      </div>
-    );
-  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -102,198 +75,94 @@ export function LoginForm() {
         <span className="h-px flex-1 bg-border" />
       </div>
 
-      {/* Tabs : password / magic link */}
-      <div
-        role="tablist"
-        aria-label={t('tabs.label')}
-        className="grid grid-cols-2 border-2 border-foreground"
-      >
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'password'}
-          onClick={() => setTab('password')}
-          className="min-h-[44px] font-mono text-xs uppercase tracking-widest transition-colors"
-          style={{
-            background:
-              tab === 'password'
-                ? 'var(--color-foreground)'
-                : 'transparent',
-            color:
-              tab === 'password'
-                ? 'var(--color-background)'
-                : 'var(--color-foreground)',
-          }}
-        >
-          {t('tabs.password')}
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'magic'}
-          onClick={() => setTab('magic')}
-          className="min-h-[44px] font-mono text-xs uppercase tracking-widest transition-colors"
-          style={{
-            background:
-              tab === 'magic' ? 'var(--color-foreground)' : 'transparent',
-            color:
-              tab === 'magic'
-                ? 'var(--color-background)'
-                : 'var(--color-foreground)',
-            borderLeft: '2px solid var(--color-foreground)',
-          }}
-        >
-          {t('tabs.magic')}
-        </button>
-      </div>
+      {/* Email + password */}
+      <form action={pwdAction} noValidate className="flex flex-col gap-4">
+        <input type="hidden" name="next" value={next} />
 
-      {tab === 'password' ? (
-        <form action={pwdAction} noValidate className="flex flex-col gap-4">
-          <input type="hidden" name="next" value={next} />
-
-          <div className="flex flex-col gap-2">
-            <Label
-              htmlFor="email"
-              className="font-mono text-xs uppercase tracking-widest"
-            >
-              {t('form.email.label')}
-            </Label>
-            <Input
-              id="email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              inputMode="email"
-              required
-              aria-invalid={
-                pwdState.status === 'error' && pwdState.field === 'email'
-              }
-              placeholder={t('form.email.placeholder')}
-              className="min-h-[48px] border-2 border-foreground text-base"
-            />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Label
-              htmlFor="password"
-              className="font-mono text-xs uppercase tracking-widest"
-            >
-              {t('form.password.label')}
-            </Label>
-            <Input
-              id="password"
-              name="password"
-              type="password"
-              autoComplete={
-                mode === 'signin' ? 'current-password' : 'new-password'
-              }
-              required
-              minLength={10}
-              aria-invalid={
-                pwdState.status === 'error' && pwdState.field === 'password'
-              }
-              aria-describedby="password-help"
-              placeholder={t('form.password.placeholder')}
-              className="min-h-[48px] border-2 border-foreground text-base"
-            />
-            <p
-              id="password-help"
-              className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground"
-            >
-              {t('form.password.help')}
-            </p>
-          </div>
-
-          {pwdState.status === 'error' && pwdState.error && (
-            <p
-              role="alert"
-              className="text-sm font-medium text-destructive"
-            >
-              {t(
-                pwdState.error.replace(
-                  'auth.',
-                  '',
-                ) as 'errors.invalidCredentials',
-              )}
-            </p>
-          )}
-
-          <Button
-            type="submit"
-            disabled={pwdPending}
-            className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+        <div className="flex flex-col gap-2">
+          <Label
+            htmlFor="email"
+            className="font-mono text-xs uppercase tracking-widest"
           >
-            {pwdPending
-              ? t('form.submitPending')
-              : mode === 'signin'
-                ? t('form.signin')
-                : t('form.signup')}
-          </Button>
+            {t('form.email.label')}
+          </Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            required
+            aria-invalid={
+              pwdState.status === 'error' && pwdState.field === 'email'
+            }
+            placeholder={t('form.email.placeholder')}
+            className="min-h-[48px] border-2 border-foreground text-base"
+          />
+        </div>
 
-          <button
-            type="button"
-            onClick={() => setMode(mode === 'signin' ? 'signup' : 'signin')}
-            className="self-start font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+        <div className="flex flex-col gap-2">
+          <Label
+            htmlFor="password"
+            className="font-mono text-xs uppercase tracking-widest"
           >
-            {mode === 'signin' ? t('form.toSignup') : t('form.toSignin')}
-          </button>
-        </form>
-      ) : (
-        <form
-          action={magicAction}
-          noValidate
-          className="flex flex-col gap-4"
-        >
-          <div className="flex flex-col gap-2">
-            <Label
-              htmlFor="magic-email"
-              className="font-mono text-xs uppercase tracking-widest"
-            >
-              {t('form.email.label')}
-            </Label>
-            <Input
-              id="magic-email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              inputMode="email"
-              required
-              aria-invalid={magicState.status === 'error'}
-              aria-describedby={
-                magicState.status === 'error' ? 'magic-error' : undefined
-              }
-              placeholder={t('form.email.placeholder')}
-              className="min-h-[48px] border-2 border-foreground text-base"
-            />
-            {magicState.status === 'error' && magicState.error && (
-              <p
-                id="magic-error"
-                role="alert"
-                className="text-sm font-medium text-destructive"
-              >
-                {t(
-                  magicState.error.replace(
-                    'auth.',
-                    '',
-                  ) as 'errors.emailInvalid',
-                )}
-              </p>
-            )}
-          </div>
-
-          <Button
-            type="submit"
-            disabled={magicPending}
-            className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+            {t('form.password.label')}
+          </Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete={
+              mode === 'signin' ? 'current-password' : 'new-password'
+            }
+            required
+            minLength={10}
+            aria-invalid={
+              pwdState.status === 'error' && pwdState.field === 'password'
+            }
+            aria-describedby="password-help"
+            placeholder={t('form.password.placeholder')}
+            className="min-h-[48px] border-2 border-foreground text-base"
+          />
+          <p
+            id="password-help"
+            className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground"
           >
-            {magicPending ? t('form.submitPending') : t('form.submit')}
-          </Button>
-
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            {t('form.hint')}
+            {t('form.password.help')}
           </p>
-        </form>
-      )}
+        </div>
+
+        {pwdState.status === 'error' && pwdState.error && (
+          <p role="alert" className="text-sm font-medium text-destructive">
+            {t(
+              pwdState.error.replace(
+                'auth.',
+                '',
+              ) as 'errors.invalidCredentials',
+            )}
+          </p>
+        )}
+
+        <Button
+          type="submit"
+          disabled={pwdPending}
+          className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+        >
+          {pwdPending
+            ? t('form.submitPending')
+            : mode === 'signin'
+              ? t('form.signin')
+              : t('form.signup')}
+        </Button>
+
+        <button
+          type="button"
+          onClick={() => setMode(mode === 'signin' ? 'signup' : 'signin')}
+          className="self-start font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+        >
+          {mode === 'signin' ? t('form.toSignup') : t('form.toSignin')}
+        </button>
+      </form>
     </div>
   );
 }

--- a/src/app/[locale]/login/login-form.tsx
+++ b/src/app/[locale]/login/login-form.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useActionState } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useActionState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { GoogleIcon } from '@/components/icons/google';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { createClient } from '@/lib/supabase/client';
 
 import { sendMagicLink, signInWithGoogle, type LoginState } from './actions';
 
@@ -15,9 +16,26 @@ const initial: LoginState = { status: 'idle' };
 
 export function LoginForm() {
   const t = useTranslations('auth');
+  const router = useRouter();
+  const locale = useLocale();
   const searchParams = useSearchParams();
   const next = searchParams.get('next') ?? '/';
   const [state, action, pending] = useActionState(sendMagicLink, initial);
+
+  // Cross-tab auth: si l'utilisateur clique le magic link dans un nouvel onglet,
+  // Supabase synchronise la session via BroadcastChannel — on redirige cet onglet aussi.
+  useEffect(() => {
+    const supabase = createClient();
+    const { data } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        const safeNext = next.startsWith('/') && !next.startsWith('//') ? next : '/';
+        const target = safeNext === '/' ? `/${locale}/dashboard` : safeNext;
+        router.replace(target);
+        router.refresh();
+      }
+    });
+    return () => data.subscription.unsubscribe();
+  }, [router, locale, next]);
 
   if (state.status === 'success') {
     return (
@@ -31,6 +49,9 @@ export function LoginForm() {
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">
           {t('checkEmail.body')}
+        </p>
+        <p className="mt-3 text-xs text-muted-foreground">
+          {t('checkEmail.hint')}
         </p>
       </div>
     );

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LangSwitcher } from '@/components/lang-switcher';
+import { ScrollToTop } from '@/components/scroll-to-top';
 import { LOCALES, type Locale } from '@/i18n/request';
 import { getUser } from '@/lib/auth';
 
@@ -89,6 +90,8 @@ export default async function HomePage({ params }: HomePageProps) {
           <p className="eyebrow">{t('footer.build')}</p>
         </div>
       </footer>
+
+      <ScrollToTop />
     </>
   );
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LangSwitcher } from '@/components/lang-switcher';
@@ -6,6 +5,11 @@ import { LOCALES, type Locale } from '@/i18n/request';
 import { getUser } from '@/lib/auth';
 
 import { signOut } from './actions';
+import { HomeFeatures } from './_home/features';
+import { HomeHero } from './_home/hero';
+import { HomeHow } from './_home/how';
+import { HomeManifesto } from './_home/manifesto';
+import { HomeVs } from './_home/vs';
 
 type HomePageProps = {
   params: Promise<{ locale: string }>;
@@ -13,200 +17,63 @@ type HomePageProps = {
 
 export default async function HomePage({ params }: HomePageProps) {
   const { locale } = await params;
-  const typedLocale = (LOCALES as readonly string[]).includes(locale)
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
     ? (locale as Locale)
     : 'fr';
   setRequestLocale(typedLocale);
 
-  const t = await getTranslations('index');
-  const tHome = await getTranslations('home');
+  const t = await getTranslations('home');
   const user = await getUser();
 
   return (
-    <main className="mx-auto max-w-7xl px-8 pb-40 pt-16">
-      <header
-        className="rise flex items-center justify-between gap-6"
-        style={{ animationDelay: '0.05s' }}
-      >
-        <span className="eyebrow inline-flex items-center">
-          <BrandDot /> {t('eyebrow')}
-        </span>
-        <div className="flex items-center gap-4">
-          {user && (
-            <div className="hidden items-center gap-3 sm:flex">
-              <span
-                className="font-mono text-xs uppercase tracking-widest"
-                style={{ color: 'var(--color-muted-foreground)' }}
-              >
-                {user.email}
-              </span>
-              <form action={signOut}>
+    <>
+      <main className="mx-auto max-w-7xl px-6 pb-32 pt-12 md:px-8">
+        <header className="rise flex items-center justify-between gap-6">
+          <span className="eyebrow inline-flex items-center">
+            <span
+              aria-hidden
+              className="mr-3 inline-block h-3 w-3 rotate-45 align-[-1px]"
+              style={{ background: 'var(--color-brand)' }}
+            />
+            {t('eyebrow')}
+          </span>
+          <div className="flex items-center gap-5">
+            {user && (
+              <form action={signOut} className="hidden sm:block">
                 <input type="hidden" name="locale" value={typedLocale} />
                 <button
                   type="submit"
                   className="font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
                   style={{ color: 'var(--color-foreground)' }}
                 >
-                  {tHome('cta.logout')}
+                  {t('cta.logout')}
                 </button>
               </form>
-            </div>
-          )}
-          <LangSwitcher />
-        </div>
-      </header>
+            )}
+            <LangSwitcher />
+          </div>
+        </header>
 
-      <section
-        className="mt-20 grid items-end gap-12 border-b pb-12 md:grid-cols-[1.2fr_1fr]"
-        style={{ borderColor: 'var(--color-border)' }}
-      >
-        <div className="rise" style={{ animationDelay: '0.15s' }}>
-          <span className="eyebrow">{t('hero.kicker')}</span>
-          <h1 className="display mt-6 text-[clamp(64px,11vw,140px)] leading-[0.95]">
-            {t('hero.train')}{' '}
-            <span
-              className="display-italic"
-              style={{ color: 'var(--color-brand)' }}
-            >
-              {t('hero.heavier')}
-            </span>
-            <br />
-            <span className="relative inline-block">
-              <span className="relative z-10">{t('hero.live')}</span>
-              <span
-                aria-hidden
-                className="absolute bottom-[0.08em] left-0 right-0 h-3 -skew-x-[8deg]"
-                style={{ background: 'var(--color-acid)', zIndex: -1 }}
-              />
-            </span>{' '}
-            {t('hero.lighter')}
-          </h1>
-        </div>
-
-        <p
-          className="rise display-italic text-xl leading-snug md:max-w-md"
-          style={{
-            animationDelay: '0.25s',
-            color:
-              'color-mix(in oklab, var(--color-foreground) 80%, transparent)',
-          }}
-        >
-          {t('lede')}
-        </p>
-      </section>
-
-      <div
-        className="mt-16 grid grid-cols-2 border-y md:grid-cols-4"
-        style={{ borderColor: 'var(--color-border)' }}
-      >
-        <MetaCell label={t('meta.stack.label')} value={t('meta.stack.value')} />
-        <MetaCell
-          label={t('meta.backend.label')}
-          value={t('meta.backend.value')}
-        />
-        <MetaCell
-          label={t('meta.budget.label')}
-          value={t('meta.budget.value')}
-        />
-        <MetaCell
-          label={t('meta.target.label')}
-          value={t('meta.target.value')}
-        />
-      </div>
-
-      <section className="mt-24">
-        <div
-          className="flex items-end justify-between gap-6 border-b pb-3"
-          style={{ borderColor: 'var(--color-border)' }}
-        >
-          <h2 className="display text-4xl md:text-5xl">
-            {t('build.heading')}{' '}
-            <em
-              className="display-italic"
-              style={{ color: 'var(--color-brand)' }}
-            >
-              {t('build.headingAccent')}
-            </em>
-          </h2>
-          <span className="eyebrow">{t('build.phase')}</span>
-        </div>
-
-        <div className="mt-10 grid gap-5 md:grid-cols-3">
-          <StatusCard
-            title={t('build.cards.stack.title')}
-            desc={t('build.cards.stack.desc')}
-            status={t('build.cards.stack.status')}
-            tone="acid"
-          />
-          <StatusCard
-            title={t('build.cards.design.title')}
-            desc={t('build.cards.design.desc')}
-            status={t('build.cards.design.status')}
-            tone="brand"
-          />
-          <StatusCard
-            title={t('build.cards.next.title')}
-            desc={t('build.cards.next.desc')}
-            status={t('build.cards.next.status')}
-            tone="default"
+        <div className="mt-20">
+          <HomeHero
+            locale={typedLocale}
+            isAuthenticated={Boolean(user)}
+            userEmail={user?.email}
           />
         </div>
 
-        <div className="mt-12 flex flex-wrap items-center gap-4">
-          {user ? (
-            <>
-              <span
-                className="eyebrow"
-                style={{ color: 'var(--color-muted-foreground)' }}
-              >
-                {tHome('greeting', { email: user.email ?? '' })}
-              </span>
-              <Link
-                href={`/${typedLocale}/dashboard`}
-                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
-                style={{
-                  background: 'var(--color-brand)',
-                  color: 'var(--color-primary-foreground)',
-                  boxShadow: 'var(--shadow-glow)',
-                }}
-              >
-                {tHome('cta.dashboard')}
-                <span className="transition-transform group-hover:translate-x-0.5">
-                  →
-                </span>
-              </Link>
-            </>
-          ) : (
-            <>
-              <Link
-                href={`/${typedLocale}/login`}
-                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
-                style={{
-                  background: 'var(--color-brand)',
-                  color: 'var(--color-primary-foreground)',
-                  boxShadow: 'var(--shadow-glow)',
-                }}
-              >
-                {tHome('cta.start')}
-                <span className="transition-transform group-hover:translate-x-0.5">
-                  →
-                </span>
-              </Link>
-              <Link
-                href={`/${typedLocale}/login`}
-                className="inline-flex min-h-12 items-center gap-2 rounded-full border px-6 py-3 font-semibold transition-colors hover:bg-[var(--color-muted)]"
-                style={{ borderColor: 'var(--color-border)' }}
-              >
-                {tHome('cta.login')}
-              </Link>
-            </>
-          )}
-        </div>
-      </section>
+        <HomeFeatures />
+
+        <HomeHow />
+
+        <HomeVs />
+      </main>
+
+      <HomeManifesto locale={typedLocale} isAuthenticated={Boolean(user)} />
 
       <footer
-        className="mt-32 border-t pt-8"
-        style={{ borderColor: 'var(--color-border)' }}
+        className="mx-auto max-w-7xl px-6 py-12 md:px-8"
+        style={{ borderTop: '1px solid var(--color-border)' }}
       >
         <div className="flex flex-wrap items-baseline justify-between gap-4">
           <p className="eyebrow">{t('footer.copyright')}</p>
@@ -222,87 +89,6 @@ export default async function HomePage({ params }: HomePageProps) {
           <p className="eyebrow">{t('footer.build')}</p>
         </div>
       </footer>
-    </main>
-  );
-}
-
-/* -------------------- Primitives -------------------- */
-
-function BrandDot() {
-  return (
-    <span
-      aria-hidden
-      className="mr-3 inline-block h-3 w-3 rotate-45 align-[-1px]"
-      style={{ background: 'var(--color-brand)' }}
-    />
-  );
-}
-
-function MetaCell({ label, value }: { label: string; value: string }) {
-  return (
-    <div
-      className="border-r p-5 last:border-r-0"
-      style={{ borderColor: 'var(--color-border)' }}
-    >
-      <div className="eyebrow">{label}</div>
-      <div className="display mt-1 text-2xl">{value}</div>
-    </div>
-  );
-}
-
-type StatusTone = 'default' | 'brand' | 'acid';
-
-function StatusCard({
-  title,
-  desc,
-  status,
-  tone,
-}: {
-  title: string;
-  desc: string;
-  status: string;
-  tone: StatusTone;
-}) {
-  const toneBg: Record<StatusTone, React.CSSProperties> = {
-    default: {
-      background: 'var(--color-card)',
-      color: 'var(--color-card-foreground)',
-      borderColor: 'var(--color-border)',
-    },
-    brand: {
-      background: 'var(--color-brand)',
-      color: 'var(--color-primary-foreground)',
-      borderColor: 'transparent',
-    },
-    acid: {
-      background: 'var(--color-acid)',
-      color: 'var(--color-ink)',
-      borderColor: 'transparent',
-    },
-  };
-  const pillBg: Record<StatusTone, React.CSSProperties> = {
-    default: {
-      background: 'var(--color-foreground)',
-      color: 'var(--color-background)',
-    },
-    brand: { background: 'rgba(255,255,255,0.2)', color: '#fff' },
-    acid: { background: 'var(--color-ink)', color: 'var(--color-acid)' },
-  };
-  return (
-    <div
-      className="relative flex flex-col gap-4 overflow-hidden rounded-xl border p-6 transition-all hover:-translate-y-1"
-      style={toneBg[tone]}
-    >
-      <div>
-        <span
-          className="mono inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.14em]"
-          style={pillBg[tone]}
-        >
-          {status}
-        </span>
-      </div>
-      <h3 className="display text-2xl leading-tight">{title}</h3>
-      <p className="text-sm leading-relaxed opacity-90">{desc}</p>
-    </div>
+    </>
   );
 }

--- a/src/components/scroll-to-top.tsx
+++ b/src/components/scroll-to-top.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+export function ScrollToTop() {
+  const t = useTranslations('common');
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <button
+      type="button"
+      aria-label={t('scrollToTop')}
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      className={[
+        'fixed bottom-6 right-6 z-50 inline-flex h-12 w-12 items-center justify-center rounded-full transition-all duration-200',
+        'border-2 hover:-translate-y-[2px]',
+        visible
+          ? 'pointer-events-auto opacity-100'
+          : 'pointer-events-none opacity-0',
+      ].join(' ')}
+      style={{
+        background: 'var(--color-brand)',
+        color: 'var(--color-primary-foreground)',
+        borderColor: 'var(--color-foreground)',
+        boxShadow: 'var(--shadow-glow)',
+      }}
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className="h-5 w-5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="square"
+        strokeLinejoin="miter"
+      >
+        <path d="M12 19V5M5 12l7-7 7 7" />
+      </svg>
+    </button>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -54,19 +54,108 @@
     }
   },
   "home": {
+    "eyebrow": "IRONTRACK · 2026 · MADE IN BELGIUM",
     "hero": {
-      "eyebrow": "Masterclass redesign",
+      "kicker": "The workshop notebook for your training",
       "train": "Train",
       "heavier": "heavier,",
       "live": "live",
       "lighter": "lighter.",
-      "lede": "A fitness app built like a workshop notebook: precise, editorial, brutalist. No confetti. No jargon. Just your body, your numbers, your progress."
+      "lede": "Track every rep, every watt, every calorie. No bullshit. No ads. No empty gamification. Just your numbers and your progress.",
+      "cta": {
+        "start": "Create my free account",
+        "discover": "Discover",
+        "dashboard": "My dashboard"
+      }
+    },
+    "features": {
+      "eyebrow": "WHAT YOU GET",
+      "heading": "Everything needed.",
+      "headingAccent": "Nothing extra.",
+      "logging": {
+        "tag": "01 · SESSIONS",
+        "title": "Log every rep, every set.",
+        "body": "Strength and cardio in a single app. Sets, reps, weight, RPE. For the rower: SPM, watts. For running: pace, elevation. Live mode with rest timer.",
+        "bullet1": "Dynamic sets",
+        "bullet2": "Advanced cardio",
+        "bullet3": "Live mode"
+      },
+      "progress": {
+        "tag": "02 · PROGRESS",
+        "title": "See where you're going.",
+        "body": "Charts of estimated 1RM, weekly volume, frequency per muscle group. Compare your cycles. Spot plateaus before they settle in.",
+        "bullet1": "Estimated 1RM",
+        "bullet2": "Weekly volume",
+        "bullet3": "Personal records"
+      },
+      "nutrition": {
+        "tag": "03 · BE NUTRITION",
+        "title": "Count macros. The Belgian way.",
+        "body": "Scan the barcode of your Colruyt, Delhaize or Carrefour product. Nutri-Score, macros, ingredients. Open Food Facts (3M+ products) at the core.",
+        "bullet1": "Barcode scan",
+        "bullet2": "Nutri-Score",
+        "bullet3": "BE products"
+      },
+      "coach": {
+        "tag": "04 · AI COACH",
+        "title": "A coach that listens.",
+        "body": "Plans adapted to your equipment, your time, your goals. Tips on plateaus. No guilt-tripping, no anxiety-inducing alerts.",
+        "bullet1": "Adapted plans",
+        "bullet2": "Anti-plateau",
+        "bullet3": "Zero pressure"
+      }
+    },
+    "how": {
+      "eyebrow": "IN 3 STEPS",
+      "heading": "How it works.",
+      "log": {
+        "title": "You log your session.",
+        "body": "During or after, doesn't matter. A few taps and it's done. The app remembers everything: your last weight, your last reps, your records."
+      },
+      "track": {
+        "title": "The app remembers everything.",
+        "body": "Your data stays yours (GDPR-first, hosted in Europe). Multi-device sync. Full export whenever you want."
+      },
+      "progress": {
+        "title": "You see your progress.",
+        "body": "No vanity metrics. Just what matters: volume, intensity, frequency, sleep, nutrition. You decide what to change."
+      }
+    },
+    "vs": {
+      "eyebrow": "POSITIONING",
+      "heading": "Why not",
+      "headingAccent": "Hevy, Strava or Whoop ?",
+      "lede": "Each app excels in its lane. IronTrack bridges them: serious strength training, precise cardio, Belgian nutrition — without forced subscription or ads.",
+      "feature": "Feature",
+      "rows": {
+        "logging": "Detailed strength training",
+        "cardio": "Cardio (rower, bike, running)",
+        "nutrition": "Nutrition + barcode scan",
+        "belgian": "Belgian products natively",
+        "noads": "Ad-free",
+        "opensource": "Open source"
+      },
+      "disclaimer": "* Comparison based on public free tiers as of April 2026"
+    },
+    "manifesto": {
+      "eyebrow": "MANIFESTO",
+      "quote": "\"The iron never lies. Neither do your numbers.\"",
+      "body": "We've seen too many fitness apps that turn training into a video game, guilt-trip you for missing a session, or sell your data. IronTrack does the opposite: a sober, precise tool that respects you.",
+      "cta": {
+        "start": "Create my free account",
+        "dashboard": "My dashboard"
+      }
     },
     "cta": {
-      "start": "Start the session",
+      "start": "Create my free account",
       "login": "Sign in",
       "dashboard": "My dashboard",
       "logout": "Sign out"
+    },
+    "footer": {
+      "copyright": "© IronTrack 2026 · Made in Belgium",
+      "quote": "\"The iron never lies.\"",
+      "build": "Build · v2.0.0-alpha"
     },
     "greeting": "Signed in as {email}"
   },
@@ -116,7 +205,8 @@
     },
     "checkEmail": {
       "title": "Check your inbox.",
-      "body": "If the address is valid, you'll receive a link in a few seconds. Don't forget to check spam."
+      "body": "If the address is valid, you'll receive a link in a few seconds. Don't forget to check spam.",
+      "hint": "The link may open in a new tab (Gmail, Outlook). No worries: this tab will update automatically as soon as you're signed in."
     },
     "errors": {
       "emailRequired": "Email is required.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -195,12 +195,26 @@
       "google": "Continue with Google",
       "or": "OR BY EMAIL"
     },
+    "tabs": {
+      "label": "Sign-in method",
+      "password": "Email + password",
+      "magic": "Magic link"
+    },
     "form": {
       "email": {
         "label": "Email",
         "placeholder": "you@example.com"
       },
+      "password": {
+        "label": "Password",
+        "placeholder": "At least 10 characters",
+        "help": "10 chars min · 1 uppercase · 1 digit"
+      },
       "submit": "Send the link",
+      "signin": "Sign in",
+      "signup": "Create account",
+      "toSignup": "No account yet? Create one",
+      "toSignin": "Already have an account? Sign in",
       "submitPending": "Sending…",
       "hint": "By continuing, you accept our terms and privacy policy (GDPR)."
     },
@@ -212,6 +226,11 @@
     "errors": {
       "emailRequired": "Email is required.",
       "emailInvalid": "This email address is not valid.",
+      "passwordTooShort": "Password too short (10 characters min).",
+      "passwordTooLong": "Password too long (72 characters max).",
+      "passwordWeak": "Add at least one uppercase, one lowercase and one digit.",
+      "invalidCredentials": "Wrong email or password.",
+      "emailTaken": "An account already exists with this email. Sign in.",
       "rateLimit": "Too many attempts. Try again in a minute.",
       "generic": "Something went wrong. Try again."
     },

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -208,7 +208,7 @@
       "password": {
         "label": "Password",
         "placeholder": "At least 10 characters",
-        "help": "10 chars min · 1 uppercase · 1 digit"
+        "help": "10 chars · 1 uppercase · 1 digit · 1 special (!@#…)"
       },
       "submit": "Send the link",
       "signin": "Sign in",
@@ -228,7 +228,7 @@
       "emailInvalid": "This email address is not valid.",
       "passwordTooShort": "Password too short (10 characters min).",
       "passwordTooLong": "Password too long (72 characters max).",
-      "passwordWeak": "Add at least one uppercase, one lowercase and one digit.",
+      "passwordWeak": "Add at least one uppercase, one lowercase, one digit and one special character (!@#$…).",
       "invalidCredentials": "Wrong email or password.",
       "emailTaken": "An account already exists with this email. Sign in.",
       "rateLimit": "Too many attempts. Try again in a minute.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1,5 +1,6 @@
 {
   "brand": { "name": "IronTrack", "tagline": "Train heavier, live lighter." },
+  "common": { "scrollToTop": "Back to top" },
   "nav": {
     "home": "Home",
     "workouts": "Sessions",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -179,11 +179,11 @@
   },
   "auth": {
     "login": {
-      "metaTitle": "Sign in · IronTrack",
-      "metaDescription": "Sign in to IronTrack with a magic link. No password required.",
+      "metaTitle": "Sign in",
+      "metaDescription": "Sign in to IronTrack with Google or with your email and password.",
       "eyebrow": "ACCESS · IRONTRACK",
       "title": "Welcome back.",
-      "lede": "Sign in with Google or get a magic link by email. No password to remember.",
+      "lede": "Sign in with Google or with your email. That's it.",
       "editorialKicker": "MANIFESTO · 01",
       "editorialQuote": "\"The iron never lies. Neither do your numbers.\"",
       "editorialAttribution": "A fitness app built like a workshop notebook. No empty gamification, no anxiety-driven notifications. Just your data, your progress, your routine.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -54,19 +54,108 @@
     }
   },
   "home": {
+    "eyebrow": "IRONTRACK · 2026 · MADE IN BELGIUM",
     "hero": {
-      "eyebrow": "Masterclass redesign",
+      "kicker": "Le carnet d'atelier de ton entraînement",
       "train": "Train",
       "heavier": "heavier,",
       "live": "live",
       "lighter": "lighter.",
-      "lede": "Une app fitness pensée comme un carnet d'atelier : précise, éditoriale, brutaliste. Pas de confettis. Pas de jargon. Juste ton corps, tes chiffres, ton progrès."
+      "lede": "Suis chaque rep, chaque watt, chaque calorie. Sans bullshit. Sans pub. Sans gamification creuse. Juste tes chiffres et ta progression.",
+      "cta": {
+        "start": "Créer mon compte gratuit",
+        "discover": "Découvrir",
+        "dashboard": "Mon tableau de bord"
+      }
+    },
+    "features": {
+      "eyebrow": "CE QUE TU OBTIENS",
+      "heading": "Tout ce qu'il faut.",
+      "headingAccent": "Rien de superflu.",
+      "logging": {
+        "tag": "01 · SÉANCES",
+        "title": "Logue chaque rep, chaque set.",
+        "body": "Musculation et cardio dans une seule app. Sets, reps, poids, RPE. Pour le rameur : SPM, watts. Pour la course : pace, dénivelé. Mode live avec timer de repos.",
+        "bullet1": "Sets dynamiques",
+        "bullet2": "Métriques cardio avancées",
+        "bullet3": "Mode live"
+      },
+      "progress": {
+        "tag": "02 · PROGRESSION",
+        "title": "Vois où tu vas. Vraiment.",
+        "body": "Graphes de 1RM estimé, volume hebdo, fréquence par groupe musculaire. Compare tes cycles. Identifie tes plateaux avant qu'ils s'installent.",
+        "bullet1": "1RM estimé",
+        "bullet2": "Volume hebdo",
+        "bullet3": "Records perso"
+      },
+      "nutrition": {
+        "tag": "03 · NUTRITION BE",
+        "title": "Compte tes macros. En belge.",
+        "body": "Scanne le code-barres de ton produit Colruyt, Delhaize ou Carrefour. Nutri-Score, macros, ingrédients. Open Food Facts (3M+ produits) en base.",
+        "bullet1": "Scan code-barres",
+        "bullet2": "Nutri-Score",
+        "bullet3": "Produits BE"
+      },
+      "coach": {
+        "tag": "04 · COACH IA",
+        "title": "Un coach qui t'écoute.",
+        "body": "Plans adaptés à ton équipement, ton temps, tes objectifs. Conseils sur tes plateaux. Sans culpabilisation, sans alertes anxiogènes.",
+        "bullet1": "Plans adaptés",
+        "bullet2": "Anti-plateau",
+        "bullet3": "Zéro pression"
+      }
+    },
+    "how": {
+      "eyebrow": "EN 3 ÉTAPES",
+      "heading": "Comment ça marche.",
+      "log": {
+        "title": "Tu logues ta séance.",
+        "body": "Pendant ou après, peu importe. Quelques tap, c'est fait. L'app retient tout : ton dernier poids, tes derniers reps, tes records."
+      },
+      "track": {
+        "title": "L'app retient tout.",
+        "body": "Tes données restent à toi (RGPD-first, hébergement Europe). Synchro multi-appareils. Export complet quand tu veux."
+      },
+      "progress": {
+        "title": "Tu vois ta progression.",
+        "body": "Pas de vanity metrics. Juste ce qui compte : volume, intensité, fréquence, sommeil, alimentation. Tu décides quoi changer."
+      }
+    },
+    "vs": {
+      "eyebrow": "POSITIONNEMENT",
+      "heading": "Pourquoi pas",
+      "headingAccent": "Hevy, Strava ou Whoop ?",
+      "lede": "Chaque app excelle dans son couloir. IronTrack fait le pont : musculation sérieuse, cardio précis, nutrition belge, le tout sans abonnement obligatoire ni publicité.",
+      "feature": "Fonctionnalité",
+      "rows": {
+        "logging": "Musculation détaillée",
+        "cardio": "Cardio (rameur, vélo, course)",
+        "nutrition": "Nutrition + scan code-barres",
+        "belgian": "Produits belges natifs",
+        "noads": "Sans pub",
+        "opensource": "Code ouvert"
+      },
+      "disclaimer": "* Comparatif basé sur les versions gratuites publiques en avril 2026"
+    },
+    "manifesto": {
+      "eyebrow": "MANIFESTE",
+      "quote": "« Le fer ne ment jamais. Tes chiffres non plus. »",
+      "body": "On a vu trop d'apps fitness qui transforment ton entraînement en jeu vidéo, te culpabilisent quand tu sautes une séance, ou vendent tes données. IronTrack fait l'inverse : un outil sobre, précis, qui te respecte.",
+      "cta": {
+        "start": "Créer mon compte gratuit",
+        "dashboard": "Mon tableau de bord"
+      }
     },
     "cta": {
-      "start": "Commencer la séance",
+      "start": "Créer mon compte gratuit",
       "login": "Se connecter",
       "dashboard": "Mon tableau de bord",
       "logout": "Se déconnecter"
+    },
+    "footer": {
+      "copyright": "© IronTrack 2026 · Made in Belgium",
+      "quote": "\"The iron never lies.\"",
+      "build": "Build · v2.0.0-alpha"
     },
     "greeting": "Connecté en tant que {email}"
   },
@@ -116,7 +205,8 @@
     },
     "checkEmail": {
       "title": "Vérifie ta boîte mail.",
-      "body": "Si l'adresse est valide, tu recevras un lien dans quelques secondes. Pense à regarder dans les spams."
+      "body": "Si l'adresse est valide, tu recevras un lien dans quelques secondes. Pense à regarder dans les spams.",
+      "hint": "Le lien peut s'ouvrir dans un nouvel onglet (Gmail, Outlook). Pas grave : cet onglet-ci se mettra à jour automatiquement dès que tu seras connecté."
     },
     "errors": {
       "emailRequired": "L'email est obligatoire.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1,5 +1,6 @@
 {
   "brand": { "name": "IronTrack", "tagline": "Train heavier, live lighter." },
+  "common": { "scrollToTop": "Retour en haut" },
   "nav": {
     "home": "Accueil",
     "workouts": "Séances",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -208,7 +208,7 @@
       "password": {
         "label": "Mot de passe",
         "placeholder": "Au moins 10 caractères",
-        "help": "10 caractères min · 1 majuscule · 1 chiffre"
+        "help": "10 caractères · 1 majuscule · 1 chiffre · 1 spécial (!@#…)"
       },
       "submit": "Recevoir le lien",
       "signin": "Se connecter",
@@ -228,7 +228,7 @@
       "emailInvalid": "Cette adresse email n'est pas valide.",
       "passwordTooShort": "Mot de passe trop court (10 caractères min).",
       "passwordTooLong": "Mot de passe trop long (72 caractères max).",
-      "passwordWeak": "Ajoute au moins une majuscule, une minuscule et un chiffre.",
+      "passwordWeak": "Ajoute au moins une majuscule, une minuscule, un chiffre et un caractère spécial (!@#$…).",
       "invalidCredentials": "Email ou mot de passe incorrect.",
       "emailTaken": "Un compte existe déjà avec cet email. Connecte-toi.",
       "rateLimit": "Trop de tentatives. Réessaie dans une minute.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -179,11 +179,11 @@
   },
   "auth": {
     "login": {
-      "metaTitle": "Connexion · IronTrack",
-      "metaDescription": "Connecte-toi à IronTrack avec un lien magique. Aucun mot de passe.",
+      "metaTitle": "Connexion",
+      "metaDescription": "Connecte-toi à IronTrack avec Google ou avec ton email et ton mot de passe.",
       "eyebrow": "ACCÈS · IRONTRACK",
       "title": "Bon retour.",
-      "lede": "Connecte-toi avec Google ou reçois un lien magique par email. Pas de mot de passe à retenir.",
+      "lede": "Connecte-toi avec Google ou avec ton email. C'est tout.",
       "editorialKicker": "MANIFESTE · 01",
       "editorialQuote": "« L'iron ne ment jamais. Tes chiffres non plus. »",
       "editorialAttribution": "Une app fitness pensée comme un carnet d'atelier. Pas de gamification creuse, pas de notifications anxiogènes. Juste tes données, tes progrès, ta routine.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -195,12 +195,26 @@
       "google": "Continuer avec Google",
       "or": "OU PAR EMAIL"
     },
+    "tabs": {
+      "label": "Méthode de connexion",
+      "password": "Email + mot de passe",
+      "magic": "Lien magique"
+    },
     "form": {
       "email": {
         "label": "Email",
         "placeholder": "tu@exemple.be"
       },
+      "password": {
+        "label": "Mot de passe",
+        "placeholder": "Au moins 10 caractères",
+        "help": "10 caractères min · 1 majuscule · 1 chiffre"
+      },
       "submit": "Recevoir le lien",
+      "signin": "Se connecter",
+      "signup": "Créer mon compte",
+      "toSignup": "Pas encore de compte ? Créer un compte",
+      "toSignin": "Déjà un compte ? Se connecter",
       "submitPending": "Envoi en cours…",
       "hint": "En continuant, tu acceptes nos conditions et notre politique de confidentialité (RGPD)."
     },
@@ -212,6 +226,11 @@
     "errors": {
       "emailRequired": "L'email est obligatoire.",
       "emailInvalid": "Cette adresse email n'est pas valide.",
+      "passwordTooShort": "Mot de passe trop court (10 caractères min).",
+      "passwordTooLong": "Mot de passe trop long (72 caractères max).",
+      "passwordWeak": "Ajoute au moins une majuscule, une minuscule et un chiffre.",
+      "invalidCredentials": "Email ou mot de passe incorrect.",
+      "emailTaken": "Un compte existe déjà avec cet email. Connecte-toi.",
       "rateLimit": "Trop de tentatives. Réessaie dans une minute.",
       "generic": "Une erreur est survenue. Réessaie."
     },

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -54,19 +54,108 @@
     }
   },
   "home": {
+    "eyebrow": "IRONTRACK · 2026 · MADE IN BELGIUM",
     "hero": {
-      "eyebrow": "Masterclass redesign",
+      "kicker": "Het atelierboek van je training",
       "train": "Train",
       "heavier": "zwaarder,",
       "live": "leef",
       "lighter": "lichter.",
-      "lede": "Een fitness-app gebouwd als een atelierboek: precies, redactioneel, brutalistisch. Geen confetti. Geen jargon. Enkel jouw lichaam, jouw cijfers, jouw vooruitgang."
+      "lede": "Volg elke rep, elke watt, elke calorie. Zonder onzin. Zonder reclame. Zonder lege gamification. Enkel je cijfers en je vooruitgang.",
+      "cta": {
+        "start": "Maak mijn gratis account",
+        "discover": "Ontdekken",
+        "dashboard": "Mijn dashboard"
+      }
+    },
+    "features": {
+      "eyebrow": "WAT JE KRIJGT",
+      "heading": "Alles wat nodig is.",
+      "headingAccent": "Niets overbodig.",
+      "logging": {
+        "tag": "01 · SESSIES",
+        "title": "Log elke rep, elke set.",
+        "body": "Krachttraining en cardio in één app. Sets, reps, gewicht, RPE. Voor de roeier: SPM, watts. Voor het lopen: tempo, hoogtemeters. Live-modus met rusttimer.",
+        "bullet1": "Dynamische sets",
+        "bullet2": "Geavanceerde cardio",
+        "bullet3": "Live-modus"
+      },
+      "progress": {
+        "tag": "02 · VOORUITGANG",
+        "title": "Zie waar je heen gaat.",
+        "body": "Grafieken van geschatte 1RM, weekvolume, frequentie per spiergroep. Vergelijk je cycli. Spot je plateaus voor ze zich vestigen.",
+        "bullet1": "Geschatte 1RM",
+        "bullet2": "Weekvolume",
+        "bullet3": "Persoonlijke records"
+      },
+      "nutrition": {
+        "tag": "03 · VOEDING BE",
+        "title": "Tel je macro's. In het Belgisch.",
+        "body": "Scan de barcode van je Colruyt, Delhaize of Carrefour-product. Nutri-Score, macro's, ingrediënten. Open Food Facts (3M+ producten) als basis.",
+        "bullet1": "Barcode scan",
+        "bullet2": "Nutri-Score",
+        "bullet3": "BE-producten"
+      },
+      "coach": {
+        "tag": "04 · AI COACH",
+        "title": "Een coach die luistert.",
+        "body": "Plannen aangepast aan je materiaal, je tijd, je doelen. Tips bij plateaus. Zonder schuldgevoel, zonder stresserende meldingen.",
+        "bullet1": "Aangepaste plannen",
+        "bullet2": "Anti-plateau",
+        "bullet3": "Geen druk"
+      }
+    },
+    "how": {
+      "eyebrow": "IN 3 STAPPEN",
+      "heading": "Hoe het werkt.",
+      "log": {
+        "title": "Je logt je sessie.",
+        "body": "Tijdens of erna, het maakt niet uit. Enkele taps en klaar. De app onthoudt alles: je laatste gewicht, je laatste reps, je records."
+      },
+      "track": {
+        "title": "De app onthoudt alles.",
+        "body": "Je data blijft van jou (AVG-first, hosting in Europa). Sync over toestellen. Volledige export wanneer je wilt."
+      },
+      "progress": {
+        "title": "Je ziet je vooruitgang.",
+        "body": "Geen vanity metrics. Enkel wat telt: volume, intensiteit, frequentie, slaap, voeding. Jij beslist wat te veranderen."
+      }
+    },
+    "vs": {
+      "eyebrow": "POSITIONERING",
+      "heading": "Waarom geen",
+      "headingAccent": "Hevy, Strava of Whoop ?",
+      "lede": "Elke app blinkt uit in haar baan. IronTrack maakt de brug: serieuze krachttraining, precieze cardio, Belgische voeding, zonder verplicht abonnement of reclame.",
+      "feature": "Functie",
+      "rows": {
+        "logging": "Gedetailleerde krachttraining",
+        "cardio": "Cardio (roeier, fiets, lopen)",
+        "nutrition": "Voeding + barcode scan",
+        "belgian": "Belgische producten native",
+        "noads": "Zonder reclame",
+        "opensource": "Open broncode"
+      },
+      "disclaimer": "* Vergelijking gebaseerd op publieke gratis versies in april 2026"
+    },
+    "manifesto": {
+      "eyebrow": "MANIFEST",
+      "quote": "« IJzer liegt nooit. Je cijfers ook niet. »",
+      "body": "We hebben te veel fitness-apps gezien die je training in een videogame veranderen, je schuld doen voelen als je een sessie overslaat, of je data verkopen. IronTrack doet het tegenovergestelde: een sober, precies werktuig dat je respecteert.",
+      "cta": {
+        "start": "Maak mijn gratis account",
+        "dashboard": "Mijn dashboard"
+      }
     },
     "cta": {
-      "start": "Sessie starten",
+      "start": "Maak mijn gratis account",
       "login": "Aanmelden",
       "dashboard": "Mijn dashboard",
       "logout": "Afmelden"
+    },
+    "footer": {
+      "copyright": "© IronTrack 2026 · Made in Belgium",
+      "quote": "\"The iron never lies.\"",
+      "build": "Build · v2.0.0-alpha"
     },
     "greeting": "Aangemeld als {email}"
   },
@@ -116,7 +205,8 @@
     },
     "checkEmail": {
       "title": "Check je inbox.",
-      "body": "Als het adres geldig is, ontvang je binnen enkele seconden een link. Vergeet je spam-map niet."
+      "body": "Als het adres geldig is, ontvang je binnen enkele seconden een link. Vergeet je spam-map niet.",
+      "hint": "De link opent mogelijk in een nieuw tabblad (Gmail, Outlook). Geen zorgen: dit tabblad wordt automatisch bijgewerkt zodra je bent aangemeld."
     },
     "errors": {
       "emailRequired": "E-mail is verplicht.",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -179,11 +179,11 @@
   },
   "auth": {
     "login": {
-      "metaTitle": "Aanmelden · IronTrack",
-      "metaDescription": "Meld je aan bij IronTrack met een magic link. Geen wachtwoord nodig.",
+      "metaTitle": "Aanmelden",
+      "metaDescription": "Meld je aan bij IronTrack met Google of met je e-mail en wachtwoord.",
       "eyebrow": "TOEGANG · IRONTRACK",
       "title": "Welkom terug.",
-      "lede": "Meld je aan met Google of ontvang een magic link per e-mail. Geen wachtwoord nodig.",
+      "lede": "Meld je aan met Google of met je e-mail. That's it.",
       "editorialKicker": "MANIFEST · 01",
       "editorialQuote": "« IJzer liegt nooit. Je cijfers ook niet. »",
       "editorialAttribution": "Een fitness-app als een atelierboek. Geen holle gamification, geen stresserende meldingen. Enkel je data, je vooruitgang, je routine.",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -195,12 +195,26 @@
       "google": "Doorgaan met Google",
       "or": "OF MET E-MAIL"
     },
+    "tabs": {
+      "label": "Aanmeldmethode",
+      "password": "E-mail + wachtwoord",
+      "magic": "Magische link"
+    },
     "form": {
       "email": {
         "label": "E-mail",
         "placeholder": "jij@voorbeeld.be"
       },
+      "password": {
+        "label": "Wachtwoord",
+        "placeholder": "Minstens 10 tekens",
+        "help": "10 tekens min · 1 hoofdletter · 1 cijfer"
+      },
       "submit": "Stuur de link",
+      "signin": "Aanmelden",
+      "signup": "Account aanmaken",
+      "toSignup": "Nog geen account? Maak er een",
+      "toSignin": "Al een account? Aanmelden",
       "submitPending": "Versturen…",
       "hint": "Door verder te gaan, aanvaard je onze voorwaarden en ons privacybeleid (AVG)."
     },
@@ -212,6 +226,11 @@
     "errors": {
       "emailRequired": "E-mail is verplicht.",
       "emailInvalid": "Dit e-mailadres is niet geldig.",
+      "passwordTooShort": "Wachtwoord te kort (minstens 10 tekens).",
+      "passwordTooLong": "Wachtwoord te lang (max 72 tekens).",
+      "passwordWeak": "Voeg minstens één hoofdletter, één kleine letter en één cijfer toe.",
+      "invalidCredentials": "E-mail of wachtwoord onjuist.",
+      "emailTaken": "Er bestaat al een account met dit e-mailadres. Meld je aan.",
       "rateLimit": "Te veel pogingen. Probeer het over een minuut opnieuw.",
       "generic": "Er is iets misgegaan. Probeer opnieuw."
     },

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -1,5 +1,6 @@
 {
   "brand": { "name": "IronTrack", "tagline": "Train zwaarder, leef lichter." },
+  "common": { "scrollToTop": "Terug naar boven" },
   "nav": {
     "home": "Start",
     "workouts": "Sessies",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -208,7 +208,7 @@
       "password": {
         "label": "Wachtwoord",
         "placeholder": "Minstens 10 tekens",
-        "help": "10 tekens min · 1 hoofdletter · 1 cijfer"
+        "help": "10 tekens · 1 hoofdletter · 1 cijfer · 1 speciaal teken (!@#…)"
       },
       "submit": "Stuur de link",
       "signin": "Aanmelden",
@@ -228,7 +228,7 @@
       "emailInvalid": "Dit e-mailadres is niet geldig.",
       "passwordTooShort": "Wachtwoord te kort (minstens 10 tekens).",
       "passwordTooLong": "Wachtwoord te lang (max 72 tekens).",
-      "passwordWeak": "Voeg minstens één hoofdletter, één kleine letter en één cijfer toe.",
+      "passwordWeak": "Voeg minstens één hoofdletter, één kleine letter, één cijfer en één speciaal teken toe (!@#$…).",
       "invalidCredentials": "E-mail of wachtwoord onjuist.",
       "emailTaken": "Er bestaat al een account met dit e-mailadres. Meld je aan.",
       "rateLimit": "Te veel pogingen. Probeer het over een minuut opnieuw.",

--- a/src/lib/auth/schema.ts
+++ b/src/lib/auth/schema.ts
@@ -25,7 +25,10 @@ export const passwordSchema = z
   .max(72, { message: 'auth.errors.passwordTooLong' })
   .regex(/[a-z]/, { message: 'auth.errors.passwordWeak' })
   .regex(/[A-Z]/, { message: 'auth.errors.passwordWeak' })
-  .regex(/[0-9]/, { message: 'auth.errors.passwordWeak' });
+  .regex(/[0-9]/, { message: 'auth.errors.passwordWeak' })
+  .regex(/[!@#$%^&*()_+\-=[\]{};':"|<>?,./`~\\]/, {
+    message: 'auth.errors.passwordWeak',
+  });
 
 export const credentialsSchema = z.object({
   email: magicLinkSchema.shape.email,

--- a/src/lib/auth/schema.ts
+++ b/src/lib/auth/schema.ts
@@ -14,3 +14,22 @@ export const magicLinkSchema = z.object({
 });
 
 export type MagicLinkInput = z.infer<typeof magicLinkSchema>;
+
+/**
+ * Schéma password : 10 chars min, au moins 1 minuscule + 1 majuscule + 1 chiffre.
+ * Aligné sur la config Supabase (password_min_length=10).
+ */
+export const passwordSchema = z
+  .string()
+  .min(10, { message: 'auth.errors.passwordTooShort' })
+  .max(72, { message: 'auth.errors.passwordTooLong' })
+  .regex(/[a-z]/, { message: 'auth.errors.passwordWeak' })
+  .regex(/[A-Z]/, { message: 'auth.errors.passwordWeak' })
+  .regex(/[0-9]/, { message: 'auth.errors.passwordWeak' });
+
+export const credentialsSchema = z.object({
+  email: magicLinkSchema.shape.email,
+  password: passwordSchema,
+});
+
+export type CredentialsInput = z.infer<typeof credentialsSchema>;


### PR DESCRIPTION
## Summary
- Home `/[locale]` refondue en sections éditoriales (hero, features, how, vs, manifesto) qui montrent enfin **ce que l'app fait** : sessions strength + cardio, progression, nutrition belge, coach IA.
- Comparatif clair vs Hevy / Strava / Whoop dans une table sobre.
- Magic link UX : listener `onAuthStateChange` côté client. Quand l'utilisateur clique le lien dans un nouvel onglet (Gmail/Outlook), l'onglet d'origine détecte la session via BroadcastChannel et redirige automatiquement vers `/[locale]/dashboard`. Hint UX ajouté pour expliquer.
- Traductions FR / NL / EN complètes.

## Stack PR
Basée sur `fix/auth-home-state` (PR #40), elle-même sur `feature/auth-oauth-redesign` (PR #39), elle-même sur `feature/auth` (PR #38).

## Test plan
- [ ] Vercel preview : `/fr` affiche les 5 sections (hero, features ×4, 3 steps, comparatif, manifesto, footer)
- [ ] CTA hero/manifesto : `/login` si déconnecté, `/dashboard` si connecté
- [ ] Header : email + "Se déconnecter" affichés quand connecté
- [ ] Magic link : envoyer → ouvrir le mail dans Gmail (nouvel onglet) → vérifier que l'onglet d'origine bascule sur `/dashboard` automatiquement
- [ ] Tester les 3 langues `/fr`, `/nl`, `/en`
- [ ] Switcher de langue conserve la session
- [ ] Lighthouse > 90 sur `/fr` (preview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)