### PR TITLE
feat(v2): masterclass refonte — auth + home + profile + avatar + mobile

### DIFF
--- a/src/app/[locale]/_home/features.tsx
+++ b/src/app/[locale]/_home/features.tsx
@@ -1,0 +1,96 @@
+import { useTranslations } from 'next-intl';
+import { Activity, BarChart3, Apple, Sparkles } from 'lucide-react';
+
+const FEATURE_KEYS = ['logging', 'progress', 'nutrition', 'coach'] as const;
+
+const ICONS = {
+  logging: Activity,
+  progress: BarChart3,
+  nutrition: Apple,
+  coach: Sparkles,
+} as const;
+
+const ACCENTS = {
+  logging: 'var(--color-brand)',
+  progress: 'var(--color-acid)',
+  nutrition: 'var(--color-azure)',
+  coach: 'var(--color-amber)',
+} as const;
+
+export function HomeFeatures() {
+  const t = useTranslations('home.features');
+
+  return (
+    <section id="features" className="mt-32">
+      <header
+        className="flex items-end justify-between gap-6 border-b pb-3"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <h2 className="display text-4xl md:text-5xl">
+          {t('heading')}{' '}
+          <em
+            className="display-italic"
+            style={{ color: 'var(--color-brand)' }}
+          >
+            {t('headingAccent')}
+          </em>
+        </h2>
+        <span className="eyebrow hidden md:inline">{t('eyebrow')}</span>
+      </header>
+
+      <div className="mt-12 grid gap-px bg-[var(--color-border)] md:grid-cols-2">
+        {FEATURE_KEYS.map((key) => {
+          const Icon = ICONS[key];
+          return (
+            <article
+              key={key}
+              className="group relative flex flex-col gap-5 p-8 transition-colors md:p-10"
+              style={{ background: 'var(--color-background)' }}
+            >
+              <div className="flex items-start justify-between">
+                <span
+                  className="flex size-12 items-center justify-center rounded-xs"
+                  style={{ background: ACCENTS[key], color: 'var(--color-ink)' }}
+                  aria-hidden
+                >
+                  <Icon className="size-6" strokeWidth={2.2} />
+                </span>
+                <span
+                  className="font-mono text-[11px] uppercase tracking-[0.2em]"
+                  style={{ color: 'var(--color-muted-foreground)' }}
+                >
+                  {t(`${key}.tag`)}
+                </span>
+              </div>
+
+              <h3 className="display text-3xl leading-tight">
+                {t(`${key}.title`)}
+              </h3>
+              <p
+                className="text-base leading-relaxed"
+                style={{ color: 'var(--color-muted-foreground)' }}
+              >
+                {t(`${key}.body`)}
+              </p>
+
+              <ul
+                className="mt-2 flex flex-wrap gap-2 font-mono text-[11px] uppercase tracking-widest"
+                style={{ color: 'var(--color-muted-foreground)' }}
+              >
+                {[1, 2, 3].map((i) => (
+                  <li
+                    key={i}
+                    className="rounded-full border px-3 py-1"
+                    style={{ borderColor: 'var(--color-border)' }}
+                  >
+                    {t(`${key}.bullet${i}`)}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/app/[locale]/_home/hero.tsx
+++ b/src/app/[locale]/_home/hero.tsx
@@ -65,13 +65,14 @@ export function HomeHero({
               {displayName && (
                 <Link
                   href={`/${locale}/profile`}
-                  className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+                  className="inline-flex min-h-11 items-center gap-2 py-2 font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
                   style={{ color: 'var(--color-muted-foreground)' }}
                 >
                   <Avatar
                     src={avatarUrl}
                     displayName={displayName}
                     size="sm"
+                    decorative
                   />
                   {displayName}
                 </Link>

--- a/src/app/[locale]/_home/hero.tsx
+++ b/src/app/[locale]/_home/hero.tsx
@@ -6,10 +6,10 @@ import type { Locale } from '@/i18n/request';
 interface HeroProps {
   locale: Locale;
   isAuthenticated: boolean;
-  userEmail?: string | null;
+  displayName?: string | null;
 }
 
-export function HomeHero({ locale, isAuthenticated, userEmail }: HeroProps) {
+export function HomeHero({ locale, isAuthenticated, displayName }: HeroProps) {
   const t = useTranslations('home.hero');
 
   return (
@@ -55,12 +55,12 @@ export function HomeHero({ locale, isAuthenticated, userEmail }: HeroProps) {
                   →
                 </span>
               </Link>
-              {userEmail && (
+              {displayName && (
                 <span
                   className="font-mono text-xs uppercase tracking-widest"
                   style={{ color: 'var(--color-muted-foreground)' }}
                 >
-                  · {userEmail}
+                  · {displayName}
                 </span>
               )}
             </>

--- a/src/app/[locale]/_home/hero.tsx
+++ b/src/app/[locale]/_home/hero.tsx
@@ -1,0 +1,106 @@
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+import type { Locale } from '@/i18n/request';
+
+interface HeroProps {
+  locale: Locale;
+  isAuthenticated: boolean;
+  userEmail?: string | null;
+}
+
+export function HomeHero({ locale, isAuthenticated, userEmail }: HeroProps) {
+  const t = useTranslations('home.hero');
+
+  return (
+    <section
+      className="rise grid items-end gap-12 border-b pb-16 md:grid-cols-[1.2fr_1fr]"
+      style={{ borderColor: 'var(--color-border)', animationDelay: '0.15s' }}
+    >
+      <div>
+        <span className="eyebrow">{t('kicker')}</span>
+        <h1 className="display mt-6 text-[clamp(56px,10vw,128px)] leading-[0.95]">
+          {t('train')}{' '}
+          <span
+            className="display-italic"
+            style={{ color: 'var(--color-brand)' }}
+          >
+            {t('heavier')}
+          </span>
+          <br />
+          <span className="relative inline-block">
+            <span className="relative z-10">{t('live')}</span>
+            <span
+              aria-hidden
+              className="absolute bottom-[0.08em] left-0 right-0 h-3 -skew-x-[8deg]"
+              style={{ background: 'var(--color-acid)', zIndex: -1 }}
+            />
+          </span>{' '}
+          {t('lighter')}
+        </h1>
+        <div className="mt-10 flex flex-wrap items-center gap-4">
+          {isAuthenticated ? (
+            <>
+              <Link
+                href={`/${locale}/dashboard`}
+                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-7 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+                style={{
+                  background: 'var(--color-brand)',
+                  color: 'var(--color-primary-foreground)',
+                  boxShadow: 'var(--shadow-glow)',
+                }}
+              >
+                {t('cta.dashboard')}
+                <span className="transition-transform group-hover:translate-x-0.5">
+                  →
+                </span>
+              </Link>
+              {userEmail && (
+                <span
+                  className="font-mono text-xs uppercase tracking-widest"
+                  style={{ color: 'var(--color-muted-foreground)' }}
+                >
+                  · {userEmail}
+                </span>
+              )}
+            </>
+          ) : (
+            <>
+              <Link
+                href={`/${locale}/login`}
+                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-7 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+                style={{
+                  background: 'var(--color-brand)',
+                  color: 'var(--color-primary-foreground)',
+                  boxShadow: 'var(--shadow-glow)',
+                }}
+              >
+                {t('cta.start')}
+                <span className="transition-transform group-hover:translate-x-0.5">
+                  →
+                </span>
+              </Link>
+              <Link
+                href="#features"
+                className="inline-flex min-h-12 items-center gap-2 rounded-full border px-6 py-3 font-semibold transition-colors hover:bg-[var(--color-muted)]"
+                style={{ borderColor: 'var(--color-border)' }}
+              >
+                {t('cta.discover')}
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+
+      <p
+        className="display-italic text-xl leading-snug md:max-w-md"
+        style={{
+          color:
+            'color-mix(in oklab, var(--color-foreground) 80%, transparent)',
+        }}
+      >
+        {t('lede')}
+      </p>
+    </section>
+  );
+}

--- a/src/app/[locale]/_home/hero.tsx
+++ b/src/app/[locale]/_home/hero.tsx
@@ -1,15 +1,22 @@
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 
+import { Avatar } from '@/components/avatar';
 import type { Locale } from '@/i18n/request';
 
 interface HeroProps {
   locale: Locale;
   isAuthenticated: boolean;
   displayName?: string | null;
+  avatarUrl?: string | null;
 }
 
-export function HomeHero({ locale, isAuthenticated, displayName }: HeroProps) {
+export function HomeHero({
+  locale,
+  isAuthenticated,
+  displayName,
+  avatarUrl,
+}: HeroProps) {
   const t = useTranslations('home.hero');
 
   return (
@@ -56,12 +63,18 @@ export function HomeHero({ locale, isAuthenticated, displayName }: HeroProps) {
                 </span>
               </Link>
               {displayName && (
-                <span
-                  className="font-mono text-xs uppercase tracking-widest"
+                <Link
+                  href={`/${locale}/profile`}
+                  className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
                   style={{ color: 'var(--color-muted-foreground)' }}
                 >
-                  · {displayName}
-                </span>
+                  <Avatar
+                    src={avatarUrl}
+                    displayName={displayName}
+                    size="sm"
+                  />
+                  {displayName}
+                </Link>
               )}
             </>
           ) : (

--- a/src/app/[locale]/_home/how.tsx
+++ b/src/app/[locale]/_home/how.tsx
@@ -1,0 +1,46 @@
+import { useTranslations } from 'next-intl';
+
+const STEPS = ['log', 'track', 'progress'] as const;
+
+export function HomeHow() {
+  const t = useTranslations('home.how');
+
+  return (
+    <section className="mt-32">
+      <header
+        className="flex items-end justify-between gap-6 border-b pb-3"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <h2 className="display text-4xl md:text-5xl">{t('heading')}</h2>
+        <span className="eyebrow hidden md:inline">{t('eyebrow')}</span>
+      </header>
+
+      <ol className="mt-12 grid gap-10 md:grid-cols-3 md:gap-16">
+        {STEPS.map((step, i) => (
+          <li key={step} className="flex flex-col gap-4">
+            <span
+              className="display text-[120px] leading-none"
+              style={{
+                color:
+                  'color-mix(in oklab, var(--color-brand) 100%, transparent)',
+                opacity: 0.85,
+              }}
+              aria-hidden
+            >
+              {String(i + 1).padStart(2, '0')}
+            </span>
+            <h3 className="display text-2xl leading-tight">
+              {t(`${step}.title`)}
+            </h3>
+            <p
+              className="text-base leading-relaxed"
+              style={{ color: 'var(--color-muted-foreground)' }}
+            >
+              {t(`${step}.body`)}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/app/[locale]/_home/manifesto.tsx
+++ b/src/app/[locale]/_home/manifesto.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+import type { Locale } from '@/i18n/request';
+
+interface ManifestoProps {
+  locale: Locale;
+  isAuthenticated: boolean;
+}
+
+export function HomeManifesto({ locale, isAuthenticated }: ManifestoProps) {
+  const t = useTranslations('home.manifesto');
+
+  return (
+    <section
+      className="mt-32 -mx-8 px-8 py-24 md:px-16 md:py-32"
+      style={{
+        background: 'var(--color-foreground)',
+        color: 'var(--color-background)',
+      }}
+    >
+      <div className="mx-auto max-w-4xl">
+        <p
+          className="font-mono text-xs uppercase tracking-[0.3em]"
+          style={{ color: 'var(--color-acid)' }}
+        >
+          {t('eyebrow')}
+        </p>
+        <blockquote className="display mt-8 text-[clamp(40px,6vw,72px)] leading-[1.05]">
+          {t('quote')}
+        </blockquote>
+        <p
+          className="mt-8 max-w-2xl text-base leading-relaxed"
+          style={{
+            color:
+              'color-mix(in oklab, var(--color-background) 75%, transparent)',
+          }}
+        >
+          {t('body')}
+        </p>
+
+        <div className="mt-12">
+          <Link
+            href={isAuthenticated ? `/${locale}/dashboard` : `/${locale}/login`}
+            className="group inline-flex min-h-12 items-center gap-2 rounded-full px-7 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+            style={{
+              background: 'var(--color-brand)',
+              color: 'var(--color-primary-foreground)',
+              boxShadow: 'var(--shadow-glow)',
+            }}
+          >
+            {t(isAuthenticated ? 'cta.dashboard' : 'cta.start')}
+            <span className="transition-transform group-hover:translate-x-0.5">
+              →
+            </span>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/[locale]/_home/vs.tsx
+++ b/src/app/[locale]/_home/vs.tsx
@@ -1,0 +1,128 @@
+import { useTranslations } from 'next-intl';
+
+const ROWS = [
+  { key: 'logging', us: true, hevy: true, strava: false, whoop: false },
+  { key: 'cardio', us: true, hevy: false, strava: true, whoop: true },
+  { key: 'nutrition', us: true, hevy: false, strava: false, whoop: false },
+  { key: 'belgian', us: true, hevy: false, strava: false, whoop: false },
+  { key: 'noads', us: true, hevy: false, strava: false, whoop: true },
+  { key: 'opensource', us: true, hevy: false, strava: false, whoop: false },
+] as const;
+
+function Cell({ on }: { on: boolean }) {
+  return (
+    <span
+      className="inline-flex size-7 items-center justify-center rounded-full font-mono text-sm"
+      style={{
+        background: on ? 'var(--color-acid)' : 'transparent',
+        color: on ? 'var(--color-ink)' : 'var(--color-muted-foreground)',
+        border: on ? 'none' : '1px solid var(--color-border)',
+      }}
+      aria-label={on ? 'oui' : 'non'}
+    >
+      {on ? '●' : '·'}
+    </span>
+  );
+}
+
+export function HomeVs() {
+  const t = useTranslations('home.vs');
+
+  return (
+    <section className="mt-32">
+      <header
+        className="flex items-end justify-between gap-6 border-b pb-3"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <h2 className="display text-4xl md:text-5xl">
+          {t('heading')}{' '}
+          <em
+            className="display-italic"
+            style={{ color: 'var(--color-brand)' }}
+          >
+            {t('headingAccent')}
+          </em>
+        </h2>
+        <span className="eyebrow hidden md:inline">{t('eyebrow')}</span>
+      </header>
+
+      <p
+        className="display-italic mt-8 max-w-2xl text-xl leading-snug"
+        style={{
+          color:
+            'color-mix(in oklab, var(--color-foreground) 80%, transparent)',
+        }}
+      >
+        {t('lede')}
+      </p>
+
+      <div className="mt-12 overflow-x-auto">
+        <table
+          className="w-full min-w-[640px] border-collapse text-left"
+          style={{ borderColor: 'var(--color-border)' }}
+        >
+          <thead>
+            <tr
+              className="font-mono text-[11px] uppercase tracking-widest"
+              style={{ color: 'var(--color-muted-foreground)' }}
+            >
+              <th className="border-b py-4 pr-4 font-normal" style={{ borderColor: 'var(--color-border)' }}>
+                {t('feature')}
+              </th>
+              <th
+                className="border-b py-4 px-3 text-center font-bold"
+                style={{
+                  borderColor: 'var(--color-border)',
+                  color: 'var(--color-brand)',
+                }}
+              >
+                IronTrack
+              </th>
+              <th className="border-b py-4 px-3 text-center font-normal" style={{ borderColor: 'var(--color-border)' }}>
+                Hevy
+              </th>
+              <th className="border-b py-4 px-3 text-center font-normal" style={{ borderColor: 'var(--color-border)' }}>
+                Strava
+              </th>
+              <th className="border-b py-4 px-3 text-center font-normal" style={{ borderColor: 'var(--color-border)' }}>
+                Whoop
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {ROWS.map((row) => (
+              <tr
+                key={row.key}
+                className="border-b text-sm"
+                style={{ borderColor: 'var(--color-border)' }}
+              >
+                <td className="py-4 pr-4 font-medium">
+                  {t(`rows.${row.key}`)}
+                </td>
+                <td className="px-3 py-4 text-center">
+                  <Cell on={row.us} />
+                </td>
+                <td className="px-3 py-4 text-center">
+                  <Cell on={row.hevy} />
+                </td>
+                <td className="px-3 py-4 text-center">
+                  <Cell on={row.strava} />
+                </td>
+                <td className="px-3 py-4 text-center">
+                  <Cell on={row.whoop} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p
+        className="mt-6 font-mono text-[11px] uppercase tracking-widest"
+        style={{ color: 'var(--color-muted-foreground)' }}
+      >
+        {t('disclaimer')}
+      </p>
+    </section>
+  );
+}

--- a/src/app/[locale]/actions.ts
+++ b/src/app/[locale]/actions.ts
@@ -1,0 +1,16 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+
+import { DEFAULT_LOCALE, type Locale } from '@/i18n/request';
+import { createServerClient } from '@/lib/supabase';
+
+/**
+ * Server Action : déconnexion + redirect vers la home locale.
+ */
+export async function signOut(formData: FormData): Promise<void> {
+  const locale = (formData.get('locale') as Locale) ?? DEFAULT_LOCALE;
+  const supabase = await createServerClient();
+  await supabase.auth.signOut();
+  redirect(`/${locale}`);
+}

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -34,7 +34,7 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
 
   return (
     <main className="mx-auto max-w-4xl px-6 py-16">
-      <header className="mb-12 flex items-start justify-between gap-4">
+      <header className="mb-12 flex flex-col items-start gap-6 sm:flex-row sm:justify-between sm:gap-4">
         <div className="flex items-start gap-5">
           <Link
             href={`/${typedLocale}/profile`}
@@ -47,19 +47,19 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
               size="lg"
             />
           </Link>
-          <div>
+          <div className="min-w-0">
             <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
               {t('eyebrow')}
             </p>
-            <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
+            <h1 className="mt-3 font-display text-4xl leading-tight text-foreground break-words sm:text-5xl">
               {t('hello', { name: displayName })}
             </h1>
-            <p className="mt-3 text-base text-muted-foreground">
+            <p className="mt-3 break-words text-base text-muted-foreground">
               {t('greeting', { email: user.email ?? '' })}
             </p>
           </div>
         </div>
-        <form action={signOut}>
+        <form action={signOut} className="shrink-0">
           <input type="hidden" name="locale" value={typedLocale} />
           <button
             type="submit"
@@ -105,13 +105,13 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
         <div className="mt-6 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
           <Link
             href={`/${typedLocale}/profile`}
-            className="underline-offset-4 hover:underline"
+            className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
           >
             {t('profileLink')} →
           </Link>
           <Link
             href={`/${typedLocale}`}
-            className="underline-offset-4 hover:underline"
+            className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
           >
             ← {t('back')}
           </Link>

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
+import { Avatar } from '@/components/avatar';
 import { LOCALES, type Locale } from '@/i18n/request';
 import { requireUser } from '@/lib/auth';
 import { getDisplayName, getProfile, needsProfileOnboarding } from '@/lib/profile';
@@ -34,16 +35,29 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
   return (
     <main className="mx-auto max-w-4xl px-6 py-16">
       <header className="mb-12 flex items-start justify-between gap-4">
-        <div>
-          <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
-            {t('eyebrow')}
-          </p>
-          <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
-            {t('hello', { name: displayName })}
-          </h1>
-          <p className="mt-3 text-base text-muted-foreground">
-            {t('greeting', { email: user.email ?? '' })}
-          </p>
+        <div className="flex items-start gap-5">
+          <Link
+            href={`/${typedLocale}/profile`}
+            aria-label={t('profileLink')}
+            className="mt-1 shrink-0"
+          >
+            <Avatar
+              src={profile?.avatar_url ?? null}
+              displayName={displayName}
+              size="lg"
+            />
+          </Link>
+          <div>
+            <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+              {t('eyebrow')}
+            </p>
+            <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
+              {t('hello', { name: displayName })}
+            </h1>
+            <p className="mt-3 text-base text-muted-foreground">
+              {t('greeting', { email: user.email ?? '' })}
+            </p>
+          </div>
         </div>
         <form action={signOut}>
           <input type="hidden" name="locale" value={typedLocale} />

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LOCALES, type Locale } from '@/i18n/request';
 import { requireUser } from '@/lib/auth';
+import { getDisplayName, getProfile, needsProfileOnboarding } from '@/lib/profile';
 
 import { signOut } from '../actions';
 
@@ -21,6 +22,10 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
     : 'fr';
   setRequestLocale(typedLocale);
   const user = await requireUser(typedLocale);
+  const profile = await getProfile();
+  const displayName = getDisplayName(profile, user);
+  const showOnboarding = needsProfileOnboarding(profile);
+
   const t = await getTranslations({
     locale: typedLocale,
     namespace: 'dashboard',
@@ -34,7 +39,7 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
             {t('eyebrow')}
           </p>
           <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
-            {t('title')}
+            {t('hello', { name: displayName })}
           </h1>
           <p className="mt-3 text-base text-muted-foreground">
             {t('greeting', { email: user.email ?? '' })}
@@ -51,6 +56,31 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
         </form>
       </header>
 
+      {showOnboarding && (
+        <section
+          className="mb-10 border-2 p-6 sm:flex sm:items-center sm:justify-between sm:gap-6"
+          style={{
+            background: 'color-mix(in oklab, var(--color-brand) 8%, transparent)',
+            borderColor: 'var(--color-brand, var(--color-foreground))',
+          }}
+        >
+          <div>
+            <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+              {t('onboarding.label')}
+            </p>
+            <p className="mt-2 font-display text-xl leading-snug text-foreground">
+              {t('onboarding.body')}
+            </p>
+          </div>
+          <Link
+            href={`/${typedLocale}/profile`}
+            className="mt-4 inline-flex min-h-[44px] items-center border-2 border-foreground bg-foreground px-5 font-mono text-xs uppercase tracking-widest text-background transition hover:bg-foreground/90 sm:mt-0 sm:shrink-0"
+          >
+            {t('onboarding.cta')}
+          </Link>
+        </section>
+      )}
+
       <section className="border-2 border-foreground p-8">
         <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
           {t('placeholder.label')}
@@ -58,12 +88,20 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
         <p className="mt-3 font-display text-2xl leading-snug text-foreground">
           {t('placeholder.body')}
         </p>
-        <Link
-          href={`/${typedLocale}`}
-          className="mt-6 inline-flex font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
-        >
-          ← {t('back')}
-        </Link>
+        <div className="mt-6 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
+          <Link
+            href={`/${typedLocale}/profile`}
+            className="underline-offset-4 hover:underline"
+          >
+            {t('profileLink')} →
+          </Link>
+          <Link
+            href={`/${typedLocale}`}
+            className="underline-offset-4 hover:underline"
+          >
+            ← {t('back')}
+          </Link>
+        </div>
       </section>
     </main>
   );

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+import { requireUser } from '@/lib/auth';
+
+import { signOut } from '../actions';
+
+interface DashboardPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export const metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default async function DashboardPage({ params }: DashboardPageProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+  const user = await requireUser(typedLocale);
+  const t = await getTranslations({
+    locale: typedLocale,
+    namespace: 'dashboard',
+  });
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-16">
+      <header className="mb-12 flex items-start justify-between gap-4">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+            {t('eyebrow')}
+          </p>
+          <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
+            {t('title')}
+          </h1>
+          <p className="mt-3 text-base text-muted-foreground">
+            {t('greeting', { email: user.email ?? '' })}
+          </p>
+        </div>
+        <form action={signOut}>
+          <input type="hidden" name="locale" value={typedLocale} />
+          <button
+            type="submit"
+            className="min-h-[44px] border border-border px-4 py-2 font-mono text-xs uppercase tracking-widest text-foreground transition hover:bg-muted"
+          >
+            {t('logout')}
+          </button>
+        </form>
+      </header>
+
+      <section className="border-2 border-foreground p-8">
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('placeholder.label')}
+        </p>
+        <p className="mt-3 font-display text-2xl leading-snug text-foreground">
+          {t('placeholder.body')}
+        </p>
+        <Link
+          href={`/${typedLocale}`}
+          className="mt-6 inline-flex font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+        >
+          ← {t('back')}
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/src/app/[locale]/legal/layout.tsx
+++ b/src/app/[locale]/legal/layout.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+
+interface LegalLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}
+
+export default async function LegalLayout({
+  children,
+  params,
+}: LegalLayoutProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16">
+      <nav className="mb-12 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
+        <Link
+          href={`/${typedLocale}`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          ← {t('nav.home')}
+        </Link>
+        <Link
+          href={`/${typedLocale}/legal/privacy`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          {t('nav.privacy')}
+        </Link>
+        <Link
+          href={`/${typedLocale}/legal/terms`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          {t('nav.terms')}
+        </Link>
+      </nav>
+      {children}
+    </main>
+  );
+}

--- a/src/app/[locale]/legal/privacy/page.tsx
+++ b/src/app/[locale]/legal/privacy/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+  return {
+    title: t('privacy.title'),
+    description: t('privacy.lede'),
+  };
+}
+
+export default async function PrivacyPage({ params }: PageProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+
+  return (
+    <article className="space-y-8">
+      <header>
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          {t('eyebrow')}
+        </p>
+        <h1 className="mt-3 font-display text-4xl leading-tight text-foreground break-words sm:text-5xl">
+          {t('privacy.title')}
+        </h1>
+        <p className="mt-4 text-base text-muted-foreground">
+          {t('privacy.lede')}
+        </p>
+      </header>
+
+      <section
+        className="border-2 p-6"
+        style={{
+          borderColor: 'var(--color-brand, var(--color-foreground))',
+          background: 'color-mix(in oklab, var(--color-brand) 8%, transparent)',
+        }}
+      >
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('draft.label')}
+        </p>
+        <p className="mt-2 font-display text-xl leading-snug text-foreground">
+          {t('draft.body')}
+        </p>
+      </section>
+
+      <section className="space-y-4 text-base text-foreground">
+        <h2 className="font-display text-2xl">{t('privacy.collect.title')}</h2>
+        <p>{t('privacy.collect.body')}</p>
+        <h2 className="font-display text-2xl">{t('privacy.usage.title')}</h2>
+        <p>{t('privacy.usage.body')}</p>
+        <h2 className="font-display text-2xl">{t('privacy.rights.title')}</h2>
+        <p>{t('privacy.rights.body')}</p>
+        <h2 className="font-display text-2xl">{t('privacy.contact.title')}</h2>
+        <p>{t('privacy.contact.body')}</p>
+      </section>
+    </article>
+  );
+}

--- a/src/app/[locale]/legal/terms/page.tsx
+++ b/src/app/[locale]/legal/terms/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+  return {
+    title: t('terms.title'),
+    description: t('terms.lede'),
+  };
+}
+
+export default async function TermsPage({ params }: PageProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+
+  return (
+    <article className="space-y-8">
+      <header>
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          {t('eyebrow')}
+        </p>
+        <h1 className="mt-3 font-display text-4xl leading-tight text-foreground break-words sm:text-5xl">
+          {t('terms.title')}
+        </h1>
+        <p className="mt-4 text-base text-muted-foreground">
+          {t('terms.lede')}
+        </p>
+      </header>
+
+      <section
+        className="border-2 p-6"
+        style={{
+          borderColor: 'var(--color-brand, var(--color-foreground))',
+          background: 'color-mix(in oklab, var(--color-brand) 8%, transparent)',
+        }}
+      >
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('draft.label')}
+        </p>
+        <p className="mt-2 font-display text-xl leading-snug text-foreground">
+          {t('draft.body')}
+        </p>
+      </section>
+
+      <section className="space-y-4 text-base text-foreground">
+        <h2 className="font-display text-2xl">{t('terms.service.title')}</h2>
+        <p>{t('terms.service.body')}</p>
+        <h2 className="font-display text-2xl">{t('terms.account.title')}</h2>
+        <p>{t('terms.account.body')}</p>
+        <h2 className="font-display text-2xl">{t('terms.content.title')}</h2>
+        <p>{t('terms.content.body')}</p>
+        <h2 className="font-display text-2xl">{t('terms.liability.title')}</h2>
+        <p>{t('terms.liability.body')}</p>
+      </section>
+    </article>
+  );
+}

--- a/src/app/[locale]/login/actions.ts
+++ b/src/app/[locale]/login/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 import { magicLinkSchema } from '@/lib/auth/schema';
 import { getClientIp, rateLimit } from '@/lib/rate-limit';
@@ -68,4 +69,50 @@ export async function sendMagicLink(
   }
 
   return { status: 'success' };
+}
+
+/**
+ * Server Action : démarre le flow OAuth Google.
+ *
+ * Sécurité :
+ *   - Rate-limit 10 req / 60s par IP
+ *   - PKCE géré côté Supabase
+ *   - `redirectTo` validé contre la redirect-allow-list Supabase
+ */
+export async function signInWithGoogle(formData: FormData): Promise<void> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`oauth:${ip}`, { limit: 10, windowMs: 60_000 });
+  if (!ok) {
+    redirect('/auth/error');
+  }
+
+  const next = formData.get('next');
+  const safeNext =
+    typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')
+      ? next
+      : '/';
+
+  const supabase = await createServerClient();
+  const origin =
+    headerList.get('origin') ??
+    `https://${headerList.get('host') ?? 'iron-track-dusky.vercel.app'}`;
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: 'google',
+    options: {
+      redirectTo: `${origin}/auth/callback?next=${encodeURIComponent(safeNext)}`,
+      queryParams: {
+        access_type: 'offline',
+        prompt: 'consent',
+      },
+    },
+  });
+
+  if (error || !data.url) {
+    redirect('/auth/error');
+  }
+
+  redirect(data.url);
 }

--- a/src/app/[locale]/login/actions.ts
+++ b/src/app/[locale]/login/actions.ts
@@ -3,17 +3,25 @@
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import { magicLinkSchema } from '@/lib/auth/schema';
+import { credentialsSchema, magicLinkSchema } from '@/lib/auth/schema';
 import { getClientIp, rateLimit } from '@/lib/rate-limit';
 import { createServerClient } from '@/lib/supabase';
 
+export type LoginErrorKey =
+  | 'auth.errors.emailRequired'
+  | 'auth.errors.emailInvalid'
+  | 'auth.errors.passwordTooShort'
+  | 'auth.errors.passwordTooLong'
+  | 'auth.errors.passwordWeak'
+  | 'auth.errors.invalidCredentials'
+  | 'auth.errors.emailTaken'
+  | 'auth.errors.rateLimit'
+  | 'auth.errors.generic';
+
 export interface LoginState {
   status: 'idle' | 'success' | 'error';
-  error?:
-    | 'auth.errors.emailRequired'
-    | 'auth.errors.emailInvalid'
-    | 'auth.errors.rateLimit'
-    | 'auth.errors.generic';
+  error?: LoginErrorKey;
+  field?: 'email' | 'password' | 'form';
 }
 
 /**
@@ -115,4 +123,114 @@ export async function signInWithGoogle(formData: FormData): Promise<void> {
   }
 
   redirect(data.url);
+}
+
+/**
+ * Server Action : sign-in classique email + password.
+ * Sécurité : rate-limit 10/min/IP, message générique en cas d'échec
+ * (pas d'enumération entre "mauvais mdp" et "user inexistant").
+ */
+export async function signInWithPassword(
+  _prev: LoginState,
+  formData: FormData,
+): Promise<LoginState> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`pwd-in:${ip}`, { limit: 10, windowMs: 60_000 });
+  if (!ok) {
+    return { status: 'error', error: 'auth.errors.rateLimit', field: 'form' };
+  }
+
+  const parsed = credentialsSchema.safeParse({
+    email: formData.get('email'),
+    password: formData.get('password'),
+  });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const msg = issue?.message as LoginErrorKey | undefined;
+    const field = (issue?.path[0] as 'email' | 'password' | undefined) ?? 'form';
+    return {
+      status: 'error',
+      error: msg ?? 'auth.errors.invalidCredentials',
+      field,
+    };
+  }
+
+  const supabase = await createServerClient();
+  const { error } = await supabase.auth.signInWithPassword({
+    email: parsed.data.email,
+    password: parsed.data.password,
+  });
+
+  if (error) {
+    return {
+      status: 'error',
+      error: 'auth.errors.invalidCredentials',
+      field: 'form',
+    };
+  }
+
+  const next = formData.get('next');
+  const safeNext =
+    typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')
+      ? next
+      : '/';
+  redirect(safeNext);
+}
+
+/**
+ * Server Action : sign-up email + password.
+ * Avec mailer_autoconfirm=true côté Supabase, le user est connecté direct
+ * sans email de confirmation.
+ */
+export async function signUpWithPassword(
+  _prev: LoginState,
+  formData: FormData,
+): Promise<LoginState> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`pwd-up:${ip}`, { limit: 5, windowMs: 60_000 });
+  if (!ok) {
+    return { status: 'error', error: 'auth.errors.rateLimit', field: 'form' };
+  }
+
+  const parsed = credentialsSchema.safeParse({
+    email: formData.get('email'),
+    password: formData.get('password'),
+  });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const msg = issue?.message as LoginErrorKey | undefined;
+    const field = (issue?.path[0] as 'email' | 'password' | undefined) ?? 'form';
+    return {
+      status: 'error',
+      error: msg ?? 'auth.errors.passwordWeak',
+      field,
+    };
+  }
+
+  const supabase = await createServerClient();
+  const { error } = await supabase.auth.signUp({
+    email: parsed.data.email,
+    password: parsed.data.password,
+  });
+
+  if (error) {
+    // Supabase renvoie "User already registered" en clair → on map sur clé i18n.
+    const isTaken = /already|exists|registered/i.test(error.message);
+    return {
+      status: 'error',
+      error: isTaken ? 'auth.errors.emailTaken' : 'auth.errors.generic',
+      field: isTaken ? 'email' : 'form',
+    };
+  }
+
+  const next = formData.get('next');
+  const safeNext =
+    typeof next === 'string' && next.startsWith('/') && !next.startsWith('//')
+      ? next
+      : '/';
+  redirect(safeNext);
 }

--- a/src/app/[locale]/login/login-form.tsx
+++ b/src/app/[locale]/login/login-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState, useEffect } from 'react';
+import { useActionState, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 
@@ -10,9 +10,18 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { createClient } from '@/lib/supabase/client';
 
-import { sendMagicLink, signInWithGoogle, type LoginState } from './actions';
+import {
+  sendMagicLink,
+  signInWithGoogle,
+  signInWithPassword,
+  signUpWithPassword,
+  type LoginState,
+} from './actions';
 
 const initial: LoginState = { status: 'idle' };
+
+type Tab = 'password' | 'magic';
+type Mode = 'signin' | 'signup';
 
 export function LoginForm() {
   const t = useTranslations('auth');
@@ -20,15 +29,27 @@ export function LoginForm() {
   const locale = useLocale();
   const searchParams = useSearchParams();
   const next = searchParams.get('next') ?? '/';
-  const [state, action, pending] = useActionState(sendMagicLink, initial);
 
-  // Cross-tab auth: si l'utilisateur clique le magic link dans un nouvel onglet,
-  // Supabase synchronise la session via BroadcastChannel — on redirige cet onglet aussi.
+  const [tab, setTab] = useState<Tab>('password');
+  const [mode, setMode] = useState<Mode>('signin');
+
+  const [magicState, magicAction, magicPending] = useActionState(
+    sendMagicLink,
+    initial,
+  );
+  const [pwdState, pwdAction, pwdPending] = useActionState(
+    mode === 'signin' ? signInWithPassword : signUpWithPassword,
+    initial,
+  );
+
+  // Cross-tab auth : si le user clique le magic link dans un autre onglet,
+  // BroadcastChannel synchronise la session — on redirige cet onglet aussi.
   useEffect(() => {
     const supabase = createClient();
     const { data } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === 'SIGNED_IN' && session) {
-        const safeNext = next.startsWith('/') && !next.startsWith('//') ? next : '/';
+        const safeNext =
+          next.startsWith('/') && !next.startsWith('//') ? next : '/';
         const target = safeNext === '/' ? `/${locale}/dashboard` : safeNext;
         router.replace(target);
         router.refresh();
@@ -37,7 +58,7 @@ export function LoginForm() {
     return () => data.subscription.unsubscribe();
   }, [router, locale, next]);
 
-  if (state.status === 'success') {
+  if (magicState.status === 'success') {
     return (
       <div
         role="status"
@@ -81,47 +102,198 @@ export function LoginForm() {
         <span className="h-px flex-1 bg-border" />
       </div>
 
-      {/* Magic link email */}
-      <form action={action} noValidate className="flex flex-col gap-4">
-        <div className="flex flex-col gap-2">
-          <Label htmlFor="email" className="font-mono text-xs uppercase tracking-widest">
-            {t('form.email.label')}
-          </Label>
-          <Input
-            id="email"
-            name="email"
-            type="email"
-            autoComplete="email"
-            inputMode="email"
-            required
-            aria-invalid={state.status === 'error'}
-            aria-describedby={state.status === 'error' ? 'email-error' : undefined}
-            placeholder={t('form.email.placeholder')}
-            className="min-h-[48px] border-2 border-foreground text-base"
-          />
-          {state.status === 'error' && state.error && (
+      {/* Tabs : password / magic link */}
+      <div
+        role="tablist"
+        aria-label={t('tabs.label')}
+        className="grid grid-cols-2 border-2 border-foreground"
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'password'}
+          onClick={() => setTab('password')}
+          className="min-h-[44px] font-mono text-xs uppercase tracking-widest transition-colors"
+          style={{
+            background:
+              tab === 'password'
+                ? 'var(--color-foreground)'
+                : 'transparent',
+            color:
+              tab === 'password'
+                ? 'var(--color-background)'
+                : 'var(--color-foreground)',
+          }}
+        >
+          {t('tabs.password')}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'magic'}
+          onClick={() => setTab('magic')}
+          className="min-h-[44px] font-mono text-xs uppercase tracking-widest transition-colors"
+          style={{
+            background:
+              tab === 'magic' ? 'var(--color-foreground)' : 'transparent',
+            color:
+              tab === 'magic'
+                ? 'var(--color-background)'
+                : 'var(--color-foreground)',
+            borderLeft: '2px solid var(--color-foreground)',
+          }}
+        >
+          {t('tabs.magic')}
+        </button>
+      </div>
+
+      {tab === 'password' ? (
+        <form action={pwdAction} noValidate className="flex flex-col gap-4">
+          <input type="hidden" name="next" value={next} />
+
+          <div className="flex flex-col gap-2">
+            <Label
+              htmlFor="email"
+              className="font-mono text-xs uppercase tracking-widest"
+            >
+              {t('form.email.label')}
+            </Label>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              inputMode="email"
+              required
+              aria-invalid={
+                pwdState.status === 'error' && pwdState.field === 'email'
+              }
+              placeholder={t('form.email.placeholder')}
+              className="min-h-[48px] border-2 border-foreground text-base"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label
+              htmlFor="password"
+              className="font-mono text-xs uppercase tracking-widest"
+            >
+              {t('form.password.label')}
+            </Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete={
+                mode === 'signin' ? 'current-password' : 'new-password'
+              }
+              required
+              minLength={10}
+              aria-invalid={
+                pwdState.status === 'error' && pwdState.field === 'password'
+              }
+              aria-describedby="password-help"
+              placeholder={t('form.password.placeholder')}
+              className="min-h-[48px] border-2 border-foreground text-base"
+            />
             <p
-              id="email-error"
+              id="password-help"
+              className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground"
+            >
+              {t('form.password.help')}
+            </p>
+          </div>
+
+          {pwdState.status === 'error' && pwdState.error && (
+            <p
               role="alert"
               className="text-sm font-medium text-destructive"
             >
-              {t(state.error.replace('auth.', '') as 'errors.emailInvalid')}
+              {t(
+                pwdState.error.replace(
+                  'auth.',
+                  '',
+                ) as 'errors.invalidCredentials',
+              )}
             </p>
           )}
-        </div>
 
-        <Button
-          type="submit"
-          disabled={pending}
-          className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+          <Button
+            type="submit"
+            disabled={pwdPending}
+            className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+          >
+            {pwdPending
+              ? t('form.submitPending')
+              : mode === 'signin'
+                ? t('form.signin')
+                : t('form.signup')}
+          </Button>
+
+          <button
+            type="button"
+            onClick={() => setMode(mode === 'signin' ? 'signup' : 'signin')}
+            className="self-start font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+          >
+            {mode === 'signin' ? t('form.toSignup') : t('form.toSignin')}
+          </button>
+        </form>
+      ) : (
+        <form
+          action={magicAction}
+          noValidate
+          className="flex flex-col gap-4"
         >
-          {pending ? t('form.submitPending') : t('form.submit')}
-        </Button>
+          <div className="flex flex-col gap-2">
+            <Label
+              htmlFor="magic-email"
+              className="font-mono text-xs uppercase tracking-widest"
+            >
+              {t('form.email.label')}
+            </Label>
+            <Input
+              id="magic-email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              inputMode="email"
+              required
+              aria-invalid={magicState.status === 'error'}
+              aria-describedby={
+                magicState.status === 'error' ? 'magic-error' : undefined
+              }
+              placeholder={t('form.email.placeholder')}
+              className="min-h-[48px] border-2 border-foreground text-base"
+            />
+            {magicState.status === 'error' && magicState.error && (
+              <p
+                id="magic-error"
+                role="alert"
+                className="text-sm font-medium text-destructive"
+              >
+                {t(
+                  magicState.error.replace(
+                    'auth.',
+                    '',
+                  ) as 'errors.emailInvalid',
+                )}
+              </p>
+            )}
+          </div>
 
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          {t('form.hint')}
-        </p>
-      </form>
+          <Button
+            type="submit"
+            disabled={magicPending}
+            className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+          >
+            {magicPending ? t('form.submitPending') : t('form.submit')}
+          </Button>
+
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {t('form.hint')}
+          </p>
+        </form>
+      )}
     </div>
   );
 }

--- a/src/app/[locale]/login/login-form.tsx
+++ b/src/app/[locale]/login/login-form.tsx
@@ -1,18 +1,22 @@
 'use client';
 
 import { useActionState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
+import { GoogleIcon } from '@/components/icons/google';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
-import { sendMagicLink, type LoginState } from './actions';
+import { sendMagicLink, signInWithGoogle, type LoginState } from './actions';
 
 const initial: LoginState = { status: 'idle' };
 
 export function LoginForm() {
   const t = useTranslations('auth');
+  const searchParams = useSearchParams();
+  const next = searchParams.get('next') ?? '/';
   const [state, action, pending] = useActionState(sendMagicLink, initial);
 
   if (state.status === 'success') {
@@ -20,50 +24,83 @@ export function LoginForm() {
       <div
         role="status"
         aria-live="polite"
-        className="border border-border bg-card p-6 text-foreground"
+        className="border-2 border-foreground bg-card p-6 text-foreground"
       >
-        <h2 className="font-display text-2xl">{t('checkEmail.title')}</h2>
-        <p className="mt-2 text-sm text-muted-foreground">{t('checkEmail.body')}</p>
+        <h2 className="font-display text-2xl leading-tight">
+          {t('checkEmail.title')}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {t('checkEmail.body')}
+        </p>
       </div>
     );
   }
 
   return (
-    <form action={action} noValidate className="flex flex-col gap-4">
-      <div className="flex flex-col gap-2">
-        <Label htmlFor="email">{t('form.email.label')}</Label>
-        <Input
-          id="email"
-          name="email"
-          type="email"
-          autoComplete="email"
-          inputMode="email"
-          required
-          aria-invalid={state.status === 'error'}
-          aria-describedby={state.status === 'error' ? 'email-error' : undefined}
-          placeholder={t('form.email.placeholder')}
-          className="min-h-[44px]"
-        />
-        {state.status === 'error' && state.error && (
-          <p
-            id="email-error"
-            role="alert"
-            className="text-sm text-destructive"
-          >
-            {t(state.error.replace('auth.', '') as 'errors.emailInvalid')}
-          </p>
-        )}
+    <div className="flex flex-col gap-6">
+      {/* OAuth Google */}
+      <form action={signInWithGoogle}>
+        <input type="hidden" name="next" value={next} />
+        <Button
+          type="submit"
+          variant="outline"
+          className="min-h-[48px] w-full justify-center gap-3 border-2 border-foreground bg-background text-base font-medium hover:bg-foreground/5"
+        >
+          <GoogleIcon className="size-5" />
+          {t('oauth.google')}
+        </Button>
+      </form>
+
+      {/* Séparateur */}
+      <div className="flex items-center gap-3" aria-hidden="true">
+        <span className="h-px flex-1 bg-border" />
+        <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('oauth.or')}
+        </span>
+        <span className="h-px flex-1 bg-border" />
       </div>
 
-      <Button
-        type="submit"
-        disabled={pending}
-        className="min-h-[44px] w-full"
-      >
-        {pending ? t('form.submitPending') : t('form.submit')}
-      </Button>
+      {/* Magic link email */}
+      <form action={action} noValidate className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="email" className="font-mono text-xs uppercase tracking-widest">
+            {t('form.email.label')}
+          </Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            required
+            aria-invalid={state.status === 'error'}
+            aria-describedby={state.status === 'error' ? 'email-error' : undefined}
+            placeholder={t('form.email.placeholder')}
+            className="min-h-[48px] border-2 border-foreground text-base"
+          />
+          {state.status === 'error' && state.error && (
+            <p
+              id="email-error"
+              role="alert"
+              className="text-sm font-medium text-destructive"
+            >
+              {t(state.error.replace('auth.', '') as 'errors.emailInvalid')}
+            </p>
+          )}
+        </div>
 
-      <p className="text-xs text-muted-foreground">{t('form.hint')}</p>
-    </form>
+        <Button
+          type="submit"
+          disabled={pending}
+          className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+        >
+          {pending ? t('form.submitPending') : t('form.submit')}
+        </Button>
+
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {t('form.hint')}
+        </p>
+      </form>
+    </div>
   );
 }

--- a/src/app/[locale]/login/login-form.tsx
+++ b/src/app/[locale]/login/login-form.tsx
@@ -11,7 +11,6 @@ import { Label } from '@/components/ui/label';
 import { createClient } from '@/lib/supabase/client';
 
 import {
-  sendMagicLink,
   signInWithGoogle,
   signInWithPassword,
   signUpWithPassword,
@@ -20,7 +19,6 @@ import {
 
 const initial: LoginState = { status: 'idle' };
 
-type Tab = 'password' | 'magic';
 type Mode = 'signin' | 'signup';
 
 export function LoginForm() {
@@ -30,20 +28,15 @@ export function LoginForm() {
   const searchParams = useSearchParams();
   const next = searchParams.get('next') ?? '/';
 
-  const [tab, setTab] = useState<Tab>('password');
   const [mode, setMode] = useState<Mode>('signin');
 
-  const [magicState, magicAction, magicPending] = useActionState(
-    sendMagicLink,
-    initial,
-  );
   const [pwdState, pwdAction, pwdPending] = useActionState(
     mode === 'signin' ? signInWithPassword : signUpWithPassword,
     initial,
   );
 
-  // Cross-tab auth : si le user clique le magic link dans un autre onglet,
-  // BroadcastChannel synchronise la session — on redirige cet onglet aussi.
+  // Sync cross-onglet : OAuth Google ouvre un onglet de redirect, on récupère
+  // la session ici dès qu'elle est posée et on redirige.
   useEffect(() => {
     const supabase = createClient();
     const { data } = supabase.auth.onAuthStateChange((event, session) => {
@@ -57,26 +50,6 @@ export function LoginForm() {
     });
     return () => data.subscription.unsubscribe();
   }, [router, locale, next]);
-
-  if (magicState.status === 'success') {
-    return (
-      <div
-        role="status"
-        aria-live="polite"
-        className="border-2 border-foreground bg-card p-6 text-foreground"
-      >
-        <h2 className="font-display text-2xl leading-tight">
-          {t('checkEmail.title')}
-        </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {t('checkEmail.body')}
-        </p>
-        <p className="mt-3 text-xs text-muted-foreground">
-          {t('checkEmail.hint')}
-        </p>
-      </div>
-    );
-  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -102,198 +75,94 @@ export function LoginForm() {
         <span className="h-px flex-1 bg-border" />
       </div>
 
-      {/* Tabs : password / magic link */}
-      <div
-        role="tablist"
-        aria-label={t('tabs.label')}
-        className="grid grid-cols-2 border-2 border-foreground"
-      >
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'password'}
-          onClick={() => setTab('password')}
-          className="min-h-[44px] font-mono text-xs uppercase tracking-widest transition-colors"
-          style={{
-            background:
-              tab === 'password'
-                ? 'var(--color-foreground)'
-                : 'transparent',
-            color:
-              tab === 'password'
-                ? 'var(--color-background)'
-                : 'var(--color-foreground)',
-          }}
-        >
-          {t('tabs.password')}
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'magic'}
-          onClick={() => setTab('magic')}
-          className="min-h-[44px] font-mono text-xs uppercase tracking-widest transition-colors"
-          style={{
-            background:
-              tab === 'magic' ? 'var(--color-foreground)' : 'transparent',
-            color:
-              tab === 'magic'
-                ? 'var(--color-background)'
-                : 'var(--color-foreground)',
-            borderLeft: '2px solid var(--color-foreground)',
-          }}
-        >
-          {t('tabs.magic')}
-        </button>
-      </div>
+      {/* Email + password */}
+      <form action={pwdAction} noValidate className="flex flex-col gap-4">
+        <input type="hidden" name="next" value={next} />
 
-      {tab === 'password' ? (
-        <form action={pwdAction} noValidate className="flex flex-col gap-4">
-          <input type="hidden" name="next" value={next} />
-
-          <div className="flex flex-col gap-2">
-            <Label
-              htmlFor="email"
-              className="font-mono text-xs uppercase tracking-widest"
-            >
-              {t('form.email.label')}
-            </Label>
-            <Input
-              id="email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              inputMode="email"
-              required
-              aria-invalid={
-                pwdState.status === 'error' && pwdState.field === 'email'
-              }
-              placeholder={t('form.email.placeholder')}
-              className="min-h-[48px] border-2 border-foreground text-base"
-            />
-          </div>
-
-          <div className="flex flex-col gap-2">
-            <Label
-              htmlFor="password"
-              className="font-mono text-xs uppercase tracking-widest"
-            >
-              {t('form.password.label')}
-            </Label>
-            <Input
-              id="password"
-              name="password"
-              type="password"
-              autoComplete={
-                mode === 'signin' ? 'current-password' : 'new-password'
-              }
-              required
-              minLength={10}
-              aria-invalid={
-                pwdState.status === 'error' && pwdState.field === 'password'
-              }
-              aria-describedby="password-help"
-              placeholder={t('form.password.placeholder')}
-              className="min-h-[48px] border-2 border-foreground text-base"
-            />
-            <p
-              id="password-help"
-              className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground"
-            >
-              {t('form.password.help')}
-            </p>
-          </div>
-
-          {pwdState.status === 'error' && pwdState.error && (
-            <p
-              role="alert"
-              className="text-sm font-medium text-destructive"
-            >
-              {t(
-                pwdState.error.replace(
-                  'auth.',
-                  '',
-                ) as 'errors.invalidCredentials',
-              )}
-            </p>
-          )}
-
-          <Button
-            type="submit"
-            disabled={pwdPending}
-            className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+        <div className="flex flex-col gap-2">
+          <Label
+            htmlFor="email"
+            className="font-mono text-xs uppercase tracking-widest"
           >
-            {pwdPending
-              ? t('form.submitPending')
-              : mode === 'signin'
-                ? t('form.signin')
-                : t('form.signup')}
-          </Button>
+            {t('form.email.label')}
+          </Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            inputMode="email"
+            required
+            aria-invalid={
+              pwdState.status === 'error' && pwdState.field === 'email'
+            }
+            placeholder={t('form.email.placeholder')}
+            className="min-h-[48px] border-2 border-foreground text-base"
+          />
+        </div>
 
-          <button
-            type="button"
-            onClick={() => setMode(mode === 'signin' ? 'signup' : 'signin')}
-            className="self-start font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+        <div className="flex flex-col gap-2">
+          <Label
+            htmlFor="password"
+            className="font-mono text-xs uppercase tracking-widest"
           >
-            {mode === 'signin' ? t('form.toSignup') : t('form.toSignin')}
-          </button>
-        </form>
-      ) : (
-        <form
-          action={magicAction}
-          noValidate
-          className="flex flex-col gap-4"
-        >
-          <div className="flex flex-col gap-2">
-            <Label
-              htmlFor="magic-email"
-              className="font-mono text-xs uppercase tracking-widest"
-            >
-              {t('form.email.label')}
-            </Label>
-            <Input
-              id="magic-email"
-              name="email"
-              type="email"
-              autoComplete="email"
-              inputMode="email"
-              required
-              aria-invalid={magicState.status === 'error'}
-              aria-describedby={
-                magicState.status === 'error' ? 'magic-error' : undefined
-              }
-              placeholder={t('form.email.placeholder')}
-              className="min-h-[48px] border-2 border-foreground text-base"
-            />
-            {magicState.status === 'error' && magicState.error && (
-              <p
-                id="magic-error"
-                role="alert"
-                className="text-sm font-medium text-destructive"
-              >
-                {t(
-                  magicState.error.replace(
-                    'auth.',
-                    '',
-                  ) as 'errors.emailInvalid',
-                )}
-              </p>
-            )}
-          </div>
-
-          <Button
-            type="submit"
-            disabled={magicPending}
-            className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+            {t('form.password.label')}
+          </Label>
+          <Input
+            id="password"
+            name="password"
+            type="password"
+            autoComplete={
+              mode === 'signin' ? 'current-password' : 'new-password'
+            }
+            required
+            minLength={10}
+            aria-invalid={
+              pwdState.status === 'error' && pwdState.field === 'password'
+            }
+            aria-describedby="password-help"
+            placeholder={t('form.password.placeholder')}
+            className="min-h-[48px] border-2 border-foreground text-base"
+          />
+          <p
+            id="password-help"
+            className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground"
           >
-            {magicPending ? t('form.submitPending') : t('form.submit')}
-          </Button>
-
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            {t('form.hint')}
+            {t('form.password.help')}
           </p>
-        </form>
-      )}
+        </div>
+
+        {pwdState.status === 'error' && pwdState.error && (
+          <p role="alert" className="text-sm font-medium text-destructive">
+            {t(
+              pwdState.error.replace(
+                'auth.',
+                '',
+              ) as 'errors.invalidCredentials',
+            )}
+          </p>
+        )}
+
+        <Button
+          type="submit"
+          disabled={pwdPending}
+          className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90"
+        >
+          {pwdPending
+            ? t('form.submitPending')
+            : mode === 'signin'
+              ? t('form.signin')
+              : t('form.signup')}
+        </Button>
+
+        <button
+          type="button"
+          onClick={() => setMode(mode === 'signin' ? 'signup' : 'signin')}
+          className="self-start font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+        >
+          {mode === 'signin' ? t('form.toSignup') : t('form.toSignin')}
+        </button>
+      </form>
     </div>
   );
 }

--- a/src/app/[locale]/login/login-form.tsx
+++ b/src/app/[locale]/login/login-form.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useActionState } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { useActionState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useLocale, useTranslations } from 'next-intl';
 
 import { GoogleIcon } from '@/components/icons/google';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { createClient } from '@/lib/supabase/client';
 
 import { sendMagicLink, signInWithGoogle, type LoginState } from './actions';
 
@@ -15,9 +16,26 @@ const initial: LoginState = { status: 'idle' };
 
 export function LoginForm() {
   const t = useTranslations('auth');
+  const router = useRouter();
+  const locale = useLocale();
   const searchParams = useSearchParams();
   const next = searchParams.get('next') ?? '/';
   const [state, action, pending] = useActionState(sendMagicLink, initial);
+
+  // Cross-tab auth: si l'utilisateur clique le magic link dans un nouvel onglet,
+  // Supabase synchronise la session via BroadcastChannel — on redirige cet onglet aussi.
+  useEffect(() => {
+    const supabase = createClient();
+    const { data } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        const safeNext = next.startsWith('/') && !next.startsWith('//') ? next : '/';
+        const target = safeNext === '/' ? `/${locale}/dashboard` : safeNext;
+        router.replace(target);
+        router.refresh();
+      }
+    });
+    return () => data.subscription.unsubscribe();
+  }, [router, locale, next]);
 
   if (state.status === 'success') {
     return (
@@ -31,6 +49,9 @@ export function LoginForm() {
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">
           {t('checkEmail.body')}
+        </p>
+        <p className="mt-3 text-xs text-muted-foreground">
+          {t('checkEmail.hint')}
         </p>
       </div>
     );

--- a/src/app/[locale]/login/page.tsx
+++ b/src/app/[locale]/login/page.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Suspense } from 'react';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LOCALES, type Locale } from '@/i18n/request';
@@ -31,20 +33,92 @@ export default async function LoginPage({ params }: LoginPageProps) {
     : 'fr';
   setRequestLocale(typedLocale);
   const t = await getTranslations({ locale: typedLocale, namespace: 'auth' });
+  const tBrand = await getTranslations({
+    locale: typedLocale,
+    namespace: 'brand',
+  });
 
   return (
-    <main className="mx-auto flex min-h-[calc(100dvh-4rem)] max-w-md flex-col justify-center px-4 py-16">
-      <header className="mb-8">
-        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
-          {t('login.eyebrow')}
-        </p>
-        <h1 className="mt-2 font-display text-4xl leading-tight text-foreground">
-          {t('login.title')}
-        </h1>
-        <p className="mt-3 text-sm text-muted-foreground">{t('login.lede')}</p>
-      </header>
+    <main className="grid min-h-dvh grid-cols-1 lg:grid-cols-[1fr_minmax(420px,520px)]">
+      {/* COLONNE GAUCHE — éditoriale brutaliste */}
+      <aside className="relative hidden flex-col justify-between bg-foreground p-12 text-background lg:flex">
+        <header className="flex items-center justify-between">
+          <Link
+            href={`/${typedLocale}`}
+            className="font-mono text-xs uppercase tracking-[0.3em] text-background/70 transition hover:text-background"
+          >
+            ← {tBrand('name')}
+          </Link>
+          <span className="font-mono text-xs uppercase tracking-[0.3em] text-background/50">
+            {t('login.eyebrow')}
+          </span>
+        </header>
 
-      <LoginForm />
+        <div className="flex flex-col gap-6">
+          <p className="font-mono text-xs uppercase tracking-[0.3em] text-[oklch(0.85_0.20_120)]">
+            {t('login.editorialKicker')}
+          </p>
+          <h2 className="font-display text-5xl leading-[1.05] tracking-tight xl:text-6xl">
+            {t('login.editorialQuote')}
+          </h2>
+          <p className="max-w-md text-base leading-relaxed text-background/70">
+            {t('login.editorialAttribution')}
+          </p>
+        </div>
+
+        <footer className="flex items-center justify-between font-mono text-xs uppercase tracking-widest text-background/50">
+          <span>© IronTrack 2026</span>
+          <span>v2.0.0-alpha</span>
+        </footer>
+      </aside>
+
+      {/* COLONNE DROITE — formulaire */}
+      <section className="flex flex-col justify-center bg-background px-6 py-12 lg:px-12">
+        <div className="mx-auto w-full max-w-sm">
+          {/* Brand mobile only */}
+          <Link
+            href={`/${typedLocale}`}
+            className="mb-12 inline-flex items-center font-mono text-xs uppercase tracking-[0.3em] text-foreground lg:hidden"
+          >
+            ← {tBrand('name')}
+          </Link>
+
+          <header className="mb-10">
+            <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+              {t('login.eyebrow')}
+            </p>
+            <h1 className="mt-3 font-display text-4xl leading-[1.05] tracking-tight text-foreground sm:text-5xl">
+              {t('login.title')}
+            </h1>
+            <p className="mt-4 text-base leading-relaxed text-muted-foreground">
+              {t('login.lede')}
+            </p>
+          </header>
+
+          <Suspense
+            fallback={<div className="h-[420px]" aria-hidden="true" />}
+          >
+            <LoginForm />
+          </Suspense>
+
+          <p className="mt-10 text-xs text-muted-foreground">
+            {t('login.terms')}{' '}
+            <Link
+              href={`/${typedLocale}/legal/privacy`}
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              {t('login.privacy')}
+            </Link>{' '}
+            ·{' '}
+            <Link
+              href={`/${typedLocale}/legal/terms`}
+              className="underline underline-offset-4 hover:text-foreground"
+            >
+              {t('login.termsLink')}
+            </Link>
+          </p>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -63,6 +63,7 @@ export default async function HomePage({ params }: HomePageProps) {
             locale={typedLocale}
             isAuthenticated={Boolean(user)}
             displayName={displayName}
+            avatarUrl={profile?.avatar_url ?? null}
           />
         </div>
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LangSwitcher } from '@/components/lang-switcher';
+import { ScrollToTop } from '@/components/scroll-to-top';
 import { LOCALES, type Locale } from '@/i18n/request';
 import { getUser } from '@/lib/auth';
 
@@ -89,6 +90,8 @@ export default async function HomePage({ params }: HomePageProps) {
           <p className="eyebrow">{t('footer.build')}</p>
         </div>
       </footer>
+
+      <ScrollToTop />
     </>
   );
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -3,6 +3,9 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LangSwitcher } from '@/components/lang-switcher';
 import { LOCALES, type Locale } from '@/i18n/request';
+import { getUser } from '@/lib/auth';
+
+import { signOut } from './actions';
 
 type HomePageProps = {
   params: Promise<{ locale: string }>;
@@ -17,6 +20,7 @@ export default async function HomePage({ params }: HomePageProps) {
 
   const t = await getTranslations('index');
   const tHome = await getTranslations('home');
+  const user = await getUser();
 
   return (
     <main className="mx-auto max-w-7xl px-8 pb-40 pt-16">
@@ -27,7 +31,29 @@ export default async function HomePage({ params }: HomePageProps) {
         <span className="eyebrow inline-flex items-center">
           <BrandDot /> {t('eyebrow')}
         </span>
-        <LangSwitcher />
+        <div className="flex items-center gap-4">
+          {user && (
+            <div className="hidden items-center gap-3 sm:flex">
+              <span
+                className="font-mono text-xs uppercase tracking-widest"
+                style={{ color: 'var(--color-muted-foreground)' }}
+              >
+                {user.email}
+              </span>
+              <form action={signOut}>
+                <input type="hidden" name="locale" value={typedLocale} />
+                <button
+                  type="submit"
+                  className="font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+                  style={{ color: 'var(--color-foreground)' }}
+                >
+                  {tHome('cta.logout')}
+                </button>
+              </form>
+            </div>
+          )}
+          <LangSwitcher />
+        </div>
       </header>
 
       <section
@@ -127,27 +153,54 @@ export default async function HomePage({ params }: HomePageProps) {
         </div>
 
         <div className="mt-12 flex flex-wrap items-center gap-4">
-          <Link
-            href={`/${typedLocale}/login`}
-            className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
-            style={{
-              background: 'var(--color-brand)',
-              color: 'var(--color-primary-foreground)',
-              boxShadow: 'var(--shadow-glow)',
-            }}
-          >
-            {tHome('cta.start')}
-            <span className="transition-transform group-hover:translate-x-0.5">
-              →
-            </span>
-          </Link>
-          <Link
-            href={`/${typedLocale}/login`}
-            className="inline-flex min-h-12 items-center gap-2 rounded-full border px-6 py-3 font-semibold transition-colors hover:bg-[var(--color-muted)]"
-            style={{ borderColor: 'var(--color-border)' }}
-          >
-            {tHome('cta.login')}
-          </Link>
+          {user ? (
+            <>
+              <span
+                className="eyebrow"
+                style={{ color: 'var(--color-muted-foreground)' }}
+              >
+                {tHome('greeting', { email: user.email ?? '' })}
+              </span>
+              <Link
+                href={`/${typedLocale}/dashboard`}
+                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+                style={{
+                  background: 'var(--color-brand)',
+                  color: 'var(--color-primary-foreground)',
+                  boxShadow: 'var(--shadow-glow)',
+                }}
+              >
+                {tHome('cta.dashboard')}
+                <span className="transition-transform group-hover:translate-x-0.5">
+                  →
+                </span>
+              </Link>
+            </>
+          ) : (
+            <>
+              <Link
+                href={`/${typedLocale}/login`}
+                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
+                style={{
+                  background: 'var(--color-brand)',
+                  color: 'var(--color-primary-foreground)',
+                  boxShadow: 'var(--shadow-glow)',
+                }}
+              >
+                {tHome('cta.start')}
+                <span className="transition-transform group-hover:translate-x-0.5">
+                  →
+                </span>
+              </Link>
+              <Link
+                href={`/${typedLocale}/login`}
+                className="inline-flex min-h-12 items-center gap-2 rounded-full border px-6 py-3 font-semibold transition-colors hover:bg-[var(--color-muted)]"
+                style={{ borderColor: 'var(--color-border)' }}
+              >
+                {tHome('cta.login')}
+              </Link>
+            </>
+          )}
         </div>
       </section>
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -4,6 +4,7 @@ import { LangSwitcher } from '@/components/lang-switcher';
 import { ScrollToTop } from '@/components/scroll-to-top';
 import { LOCALES, type Locale } from '@/i18n/request';
 import { getUser } from '@/lib/auth';
+import { getDisplayName, getProfile } from '@/lib/profile';
 
 import { signOut } from './actions';
 import { HomeFeatures } from './_home/features';
@@ -25,6 +26,8 @@ export default async function HomePage({ params }: HomePageProps) {
 
   const t = await getTranslations('home');
   const user = await getUser();
+  const profile = user ? await getProfile() : null;
+  const displayName = user ? getDisplayName(profile, user) : null;
 
   return (
     <>
@@ -59,7 +62,7 @@ export default async function HomePage({ params }: HomePageProps) {
           <HomeHero
             locale={typedLocale}
             isAuthenticated={Boolean(user)}
-            userEmail={user?.email}
+            displayName={displayName}
           />
         </div>
 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LangSwitcher } from '@/components/lang-switcher';
@@ -6,6 +5,11 @@ import { LOCALES, type Locale } from '@/i18n/request';
 import { getUser } from '@/lib/auth';
 
 import { signOut } from './actions';
+import { HomeFeatures } from './_home/features';
+import { HomeHero } from './_home/hero';
+import { HomeHow } from './_home/how';
+import { HomeManifesto } from './_home/manifesto';
+import { HomeVs } from './_home/vs';
 
 type HomePageProps = {
   params: Promise<{ locale: string }>;
@@ -13,200 +17,63 @@ type HomePageProps = {
 
 export default async function HomePage({ params }: HomePageProps) {
   const { locale } = await params;
-  const typedLocale = (LOCALES as readonly string[]).includes(locale)
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
     ? (locale as Locale)
     : 'fr';
   setRequestLocale(typedLocale);
 
-  const t = await getTranslations('index');
-  const tHome = await getTranslations('home');
+  const t = await getTranslations('home');
   const user = await getUser();
 
   return (
-    <main className="mx-auto max-w-7xl px-8 pb-40 pt-16">
-      <header
-        className="rise flex items-center justify-between gap-6"
-        style={{ animationDelay: '0.05s' }}
-      >
-        <span className="eyebrow inline-flex items-center">
-          <BrandDot /> {t('eyebrow')}
-        </span>
-        <div className="flex items-center gap-4">
-          {user && (
-            <div className="hidden items-center gap-3 sm:flex">
-              <span
-                className="font-mono text-xs uppercase tracking-widest"
-                style={{ color: 'var(--color-muted-foreground)' }}
-              >
-                {user.email}
-              </span>
-              <form action={signOut}>
+    <>
+      <main className="mx-auto max-w-7xl px-6 pb-32 pt-12 md:px-8">
+        <header className="rise flex items-center justify-between gap-6">
+          <span className="eyebrow inline-flex items-center">
+            <span
+              aria-hidden
+              className="mr-3 inline-block h-3 w-3 rotate-45 align-[-1px]"
+              style={{ background: 'var(--color-brand)' }}
+            />
+            {t('eyebrow')}
+          </span>
+          <div className="flex items-center gap-5">
+            {user && (
+              <form action={signOut} className="hidden sm:block">
                 <input type="hidden" name="locale" value={typedLocale} />
                 <button
                   type="submit"
                   className="font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
                   style={{ color: 'var(--color-foreground)' }}
                 >
-                  {tHome('cta.logout')}
+                  {t('cta.logout')}
                 </button>
               </form>
-            </div>
-          )}
-          <LangSwitcher />
-        </div>
-      </header>
+            )}
+            <LangSwitcher />
+          </div>
+        </header>
 
-      <section
-        className="mt-20 grid items-end gap-12 border-b pb-12 md:grid-cols-[1.2fr_1fr]"
-        style={{ borderColor: 'var(--color-border)' }}
-      >
-        <div className="rise" style={{ animationDelay: '0.15s' }}>
-          <span className="eyebrow">{t('hero.kicker')}</span>
-          <h1 className="display mt-6 text-[clamp(64px,11vw,140px)] leading-[0.95]">
-            {t('hero.train')}{' '}
-            <span
-              className="display-italic"
-              style={{ color: 'var(--color-brand)' }}
-            >
-              {t('hero.heavier')}
-            </span>
-            <br />
-            <span className="relative inline-block">
-              <span className="relative z-10">{t('hero.live')}</span>
-              <span
-                aria-hidden
-                className="absolute bottom-[0.08em] left-0 right-0 h-3 -skew-x-[8deg]"
-                style={{ background: 'var(--color-acid)', zIndex: -1 }}
-              />
-            </span>{' '}
-            {t('hero.lighter')}
-          </h1>
-        </div>
-
-        <p
-          className="rise display-italic text-xl leading-snug md:max-w-md"
-          style={{
-            animationDelay: '0.25s',
-            color:
-              'color-mix(in oklab, var(--color-foreground) 80%, transparent)',
-          }}
-        >
-          {t('lede')}
-        </p>
-      </section>
-
-      <div
-        className="mt-16 grid grid-cols-2 border-y md:grid-cols-4"
-        style={{ borderColor: 'var(--color-border)' }}
-      >
-        <MetaCell label={t('meta.stack.label')} value={t('meta.stack.value')} />
-        <MetaCell
-          label={t('meta.backend.label')}
-          value={t('meta.backend.value')}
-        />
-        <MetaCell
-          label={t('meta.budget.label')}
-          value={t('meta.budget.value')}
-        />
-        <MetaCell
-          label={t('meta.target.label')}
-          value={t('meta.target.value')}
-        />
-      </div>
-
-      <section className="mt-24">
-        <div
-          className="flex items-end justify-between gap-6 border-b pb-3"
-          style={{ borderColor: 'var(--color-border)' }}
-        >
-          <h2 className="display text-4xl md:text-5xl">
-            {t('build.heading')}{' '}
-            <em
-              className="display-italic"
-              style={{ color: 'var(--color-brand)' }}
-            >
-              {t('build.headingAccent')}
-            </em>
-          </h2>
-          <span className="eyebrow">{t('build.phase')}</span>
-        </div>
-
-        <div className="mt-10 grid gap-5 md:grid-cols-3">
-          <StatusCard
-            title={t('build.cards.stack.title')}
-            desc={t('build.cards.stack.desc')}
-            status={t('build.cards.stack.status')}
-            tone="acid"
-          />
-          <StatusCard
-            title={t('build.cards.design.title')}
-            desc={t('build.cards.design.desc')}
-            status={t('build.cards.design.status')}
-            tone="brand"
-          />
-          <StatusCard
-            title={t('build.cards.next.title')}
-            desc={t('build.cards.next.desc')}
-            status={t('build.cards.next.status')}
-            tone="default"
+        <div className="mt-20">
+          <HomeHero
+            locale={typedLocale}
+            isAuthenticated={Boolean(user)}
+            userEmail={user?.email}
           />
         </div>
 
-        <div className="mt-12 flex flex-wrap items-center gap-4">
-          {user ? (
-            <>
-              <span
-                className="eyebrow"
-                style={{ color: 'var(--color-muted-foreground)' }}
-              >
-                {tHome('greeting', { email: user.email ?? '' })}
-              </span>
-              <Link
-                href={`/${typedLocale}/dashboard`}
-                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
-                style={{
-                  background: 'var(--color-brand)',
-                  color: 'var(--color-primary-foreground)',
-                  boxShadow: 'var(--shadow-glow)',
-                }}
-              >
-                {tHome('cta.dashboard')}
-                <span className="transition-transform group-hover:translate-x-0.5">
-                  →
-                </span>
-              </Link>
-            </>
-          ) : (
-            <>
-              <Link
-                href={`/${typedLocale}/login`}
-                className="group inline-flex min-h-12 items-center gap-2 rounded-full px-6 py-3 font-semibold transition-transform hover:-translate-y-[1px]"
-                style={{
-                  background: 'var(--color-brand)',
-                  color: 'var(--color-primary-foreground)',
-                  boxShadow: 'var(--shadow-glow)',
-                }}
-              >
-                {tHome('cta.start')}
-                <span className="transition-transform group-hover:translate-x-0.5">
-                  →
-                </span>
-              </Link>
-              <Link
-                href={`/${typedLocale}/login`}
-                className="inline-flex min-h-12 items-center gap-2 rounded-full border px-6 py-3 font-semibold transition-colors hover:bg-[var(--color-muted)]"
-                style={{ borderColor: 'var(--color-border)' }}
-              >
-                {tHome('cta.login')}
-              </Link>
-            </>
-          )}
-        </div>
-      </section>
+        <HomeFeatures />
+
+        <HomeHow />
+
+        <HomeVs />
+      </main>
+
+      <HomeManifesto locale={typedLocale} isAuthenticated={Boolean(user)} />
 
       <footer
-        className="mt-32 border-t pt-8"
-        style={{ borderColor: 'var(--color-border)' }}
+        className="mx-auto max-w-7xl px-6 py-12 md:px-8"
+        style={{ borderTop: '1px solid var(--color-border)' }}
       >
         <div className="flex flex-wrap items-baseline justify-between gap-4">
           <p className="eyebrow">{t('footer.copyright')}</p>
@@ -222,87 +89,6 @@ export default async function HomePage({ params }: HomePageProps) {
           <p className="eyebrow">{t('footer.build')}</p>
         </div>
       </footer>
-    </main>
-  );
-}
-
-/* -------------------- Primitives -------------------- */
-
-function BrandDot() {
-  return (
-    <span
-      aria-hidden
-      className="mr-3 inline-block h-3 w-3 rotate-45 align-[-1px]"
-      style={{ background: 'var(--color-brand)' }}
-    />
-  );
-}
-
-function MetaCell({ label, value }: { label: string; value: string }) {
-  return (
-    <div
-      className="border-r p-5 last:border-r-0"
-      style={{ borderColor: 'var(--color-border)' }}
-    >
-      <div className="eyebrow">{label}</div>
-      <div className="display mt-1 text-2xl">{value}</div>
-    </div>
-  );
-}
-
-type StatusTone = 'default' | 'brand' | 'acid';
-
-function StatusCard({
-  title,
-  desc,
-  status,
-  tone,
-}: {
-  title: string;
-  desc: string;
-  status: string;
-  tone: StatusTone;
-}) {
-  const toneBg: Record<StatusTone, React.CSSProperties> = {
-    default: {
-      background: 'var(--color-card)',
-      color: 'var(--color-card-foreground)',
-      borderColor: 'var(--color-border)',
-    },
-    brand: {
-      background: 'var(--color-brand)',
-      color: 'var(--color-primary-foreground)',
-      borderColor: 'transparent',
-    },
-    acid: {
-      background: 'var(--color-acid)',
-      color: 'var(--color-ink)',
-      borderColor: 'transparent',
-    },
-  };
-  const pillBg: Record<StatusTone, React.CSSProperties> = {
-    default: {
-      background: 'var(--color-foreground)',
-      color: 'var(--color-background)',
-    },
-    brand: { background: 'rgba(255,255,255,0.2)', color: '#fff' },
-    acid: { background: 'var(--color-ink)', color: 'var(--color-acid)' },
-  };
-  return (
-    <div
-      className="relative flex flex-col gap-4 overflow-hidden rounded-xl border p-6 transition-all hover:-translate-y-1"
-      style={toneBg[tone]}
-    >
-      <div>
-        <span
-          className="mono inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.14em]"
-          style={pillBg[tone]}
-        >
-          {status}
-        </span>
-      </div>
-      <h3 className="display text-2xl leading-tight">{title}</h3>
-      <p className="text-sm leading-relaxed opacity-90">{desc}</p>
-    </div>
+    </>
   );
 }

--- a/src/app/[locale]/profile/actions.ts
+++ b/src/app/[locale]/profile/actions.ts
@@ -1,0 +1,90 @@
+'use server';
+
+import { headers } from 'next/headers';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+import { DEFAULT_LOCALE, LOCALES, type Locale } from '@/i18n/request';
+import { getClientIp, rateLimit } from '@/lib/rate-limit';
+import { profileFormSchema } from '@/lib/profile/schema';
+import { createServerClient } from '@/lib/supabase';
+
+export type ProfileErrorKey =
+  | 'profile.errors.pseudoTooShort'
+  | 'profile.errors.pseudoTooLong'
+  | 'profile.errors.pseudoFormat'
+  | 'profile.errors.pseudoTaken'
+  | 'profile.errors.fullNameRequired'
+  | 'profile.errors.fullNameTooLong'
+  | 'profile.errors.rateLimit'
+  | 'profile.errors.generic';
+
+export interface ProfileState {
+  status: 'idle' | 'success' | 'error';
+  error?: ProfileErrorKey;
+  field?: 'pseudo' | 'full_name' | 'form';
+}
+
+function isLocale(l: string): l is Locale {
+  return (LOCALES as readonly string[]).includes(l);
+}
+
+export async function updateProfile(
+  _prev: ProfileState,
+  formData: FormData,
+): Promise<ProfileState> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`profile:${ip}`, { limit: 10, windowMs: 60_000 });
+  if (!ok) {
+    return { status: 'error', error: 'profile.errors.rateLimit', field: 'form' };
+  }
+
+  const rawLocale = String(formData.get('locale') ?? '');
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+
+  const parsed = profileFormSchema.safeParse({
+    pseudo: formData.get('pseudo'),
+    full_name: formData.get('full_name'),
+  });
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const field = issue?.path[0];
+    return {
+      status: 'error',
+      error: (issue?.message ?? 'profile.errors.generic') as ProfileErrorKey,
+      field: field === 'pseudo' || field === 'full_name' ? field : 'form',
+    };
+  }
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/${locale}/login`);
+  }
+
+  const { pseudo, full_name } = parsed.data;
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ pseudo, full_name })
+    .eq('id', user.id);
+
+  if (error) {
+    // Postgres 23505 : unique_violation (pseudo déjà pris, case-insensitive)
+    // Message type : "duplicate key value violates unique constraint"
+    if (error.code === '23505' || /duplicate key|unique constraint/i.test(error.message)) {
+      return { status: 'error', error: 'profile.errors.pseudoTaken', field: 'pseudo' };
+    }
+    return { status: 'error', error: 'profile.errors.generic', field: 'form' };
+  }
+
+  revalidatePath(`/${locale}/profile`);
+  revalidatePath(`/${locale}/dashboard`);
+  revalidatePath(`/${locale}`);
+
+  return { status: 'success' };
+}

--- a/src/app/[locale]/profile/actions.ts
+++ b/src/app/[locale]/profile/actions.ts
@@ -5,6 +5,13 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { DEFAULT_LOCALE, LOCALES, type Locale } from '@/i18n/request';
+import {
+  AVATAR_BUCKET,
+  AVATAR_MAX_BYTES,
+  buildAvatarPath,
+  isAvatarMimeType,
+  pathFromPublicUrl,
+} from '@/lib/profile/avatar';
 import { getClientIp, rateLimit } from '@/lib/rate-limit';
 import { profileFormSchema } from '@/lib/profile/schema';
 import { createServerClient } from '@/lib/supabase';
@@ -16,13 +23,23 @@ export type ProfileErrorKey =
   | 'profile.errors.pseudoTaken'
   | 'profile.errors.fullNameRequired'
   | 'profile.errors.fullNameTooLong'
+  | 'profile.errors.avatarTooLarge'
+  | 'profile.errors.avatarMimeType'
+  | 'profile.errors.avatarUpload'
   | 'profile.errors.rateLimit'
   | 'profile.errors.generic';
 
 export interface ProfileState {
   status: 'idle' | 'success' | 'error';
   error?: ProfileErrorKey;
-  field?: 'pseudo' | 'full_name' | 'form';
+  field?: 'pseudo' | 'full_name' | 'avatar' | 'form';
+}
+
+export interface AvatarState {
+  status: 'idle' | 'success' | 'error';
+  error?: ProfileErrorKey;
+  /** URL publique fraîche (avec cache-buster) après un upload réussi. */
+  avatarUrl?: string | null;
 }
 
 function isLocale(l: string): l is Locale {
@@ -87,4 +104,157 @@ export async function updateProfile(
   revalidatePath(`/${locale}`);
 
   return { status: 'success' };
+}
+
+/**
+ * Upload d'un avatar dans le bucket Storage `avatars`.
+ *
+ * Sécurité :
+ *   - Auth obligatoire
+ *   - Rate-limit 5 / 60s par IP (contre abus storage)
+ *   - Validation taille (5 MB) + mime (jpeg/png/webp/gif)
+ *   - Path forcé `${userId}/uuid.ext` (RLS bucket le requiert)
+ *   - L'ancien fichier (s'il existait) est supprimé après succès
+ *
+ * Retour : nouvelle URL publique avec cache-buster `?v=Date.now()`.
+ */
+export async function uploadAvatar(
+  _prev: AvatarState,
+  formData: FormData,
+): Promise<AvatarState> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`avatar:${ip}`, { limit: 5, windowMs: 60_000 });
+  if (!ok) {
+    return { status: 'error', error: 'profile.errors.rateLimit' };
+  }
+
+  const rawLocale = String(formData.get('locale') ?? '');
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+
+  const file = formData.get('avatar');
+  if (!(file instanceof File) || file.size === 0) {
+    return { status: 'error', error: 'profile.errors.generic' };
+  }
+
+  if (file.size > AVATAR_MAX_BYTES) {
+    return { status: 'error', error: 'profile.errors.avatarTooLarge' };
+  }
+  if (!isAvatarMimeType(file.type)) {
+    return { status: 'error', error: 'profile.errors.avatarMimeType' };
+  }
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/${locale}/login`);
+  }
+
+  // Ancienne URL (pour cleanup après succès)
+  const { data: current } = await supabase
+    .from('profiles')
+    .select('avatar_url')
+    .eq('id', user.id)
+    .maybeSingle();
+  const previousPath = pathFromPublicUrl(current?.avatar_url);
+
+  const path = buildAvatarPath(user.id, file.type);
+  const { error: uploadErr } = await supabase.storage
+    .from(AVATAR_BUCKET)
+    .upload(path, file, {
+      cacheControl: '3600',
+      contentType: file.type,
+      upsert: false,
+    });
+
+  if (uploadErr) {
+    console.error('[uploadAvatar] storage error:', uploadErr.message);
+    return { status: 'error', error: 'profile.errors.avatarUpload' };
+  }
+
+  const { data: pub } = supabase.storage.from(AVATAR_BUCKET).getPublicUrl(path);
+  const publicUrl = pub.publicUrl;
+
+  const { error: updateErr } = await supabase
+    .from('profiles')
+    .update({ avatar_url: publicUrl })
+    .eq('id', user.id);
+
+  if (updateErr) {
+    // Cleanup : on tente de retirer le fichier qu'on vient d'uploader pour
+    // éviter un orphelin.
+    await supabase.storage.from(AVATAR_BUCKET).remove([path]);
+    return { status: 'error', error: 'profile.errors.generic' };
+  }
+
+  // Cleanup ancien avatar (best-effort, on ignore les erreurs)
+  if (previousPath && previousPath !== path) {
+    await supabase.storage.from(AVATAR_BUCKET).remove([previousPath]);
+  }
+
+  revalidatePath(`/${locale}/profile`);
+  revalidatePath(`/${locale}/dashboard`);
+  revalidatePath(`/${locale}`);
+
+  return {
+    status: 'success',
+    avatarUrl: `${publicUrl}?v=${Date.now()}`,
+  };
+}
+
+/**
+ * Supprime l'avatar : clear `profiles.avatar_url` + delete du fichier storage.
+ */
+export async function removeAvatar(
+  _prev: AvatarState,
+  formData: FormData,
+): Promise<AvatarState> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`avatar:${ip}`, { limit: 5, windowMs: 60_000 });
+  if (!ok) {
+    return { status: 'error', error: 'profile.errors.rateLimit' };
+  }
+
+  const rawLocale = String(formData.get('locale') ?? '');
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/${locale}/login`);
+  }
+
+  const { data: current } = await supabase
+    .from('profiles')
+    .select('avatar_url')
+    .eq('id', user.id)
+    .maybeSingle();
+  const path = pathFromPublicUrl(current?.avatar_url);
+
+  const { error: updateErr } = await supabase
+    .from('profiles')
+    .update({ avatar_url: null })
+    .eq('id', user.id);
+
+  if (updateErr) {
+    return { status: 'error', error: 'profile.errors.generic' };
+  }
+
+  // Cleanup best-effort
+  if (path) {
+    await supabase.storage.from(AVATAR_BUCKET).remove([path]);
+  }
+
+  revalidatePath(`/${locale}/profile`);
+  revalidatePath(`/${locale}/dashboard`);
+  revalidatePath(`/${locale}`);
+
+  return { status: 'success', avatarUrl: null };
 }

--- a/src/app/[locale]/profile/avatar-uploader.tsx
+++ b/src/app/[locale]/profile/avatar-uploader.tsx
@@ -69,10 +69,18 @@ export function AvatarUploader({
       <Avatar src={previewUrl} displayName={displayName} size="xl" />
 
       <div className="flex flex-col gap-3">
+        {/*
+          Deux <form> frères (non imbriqués) — le bouton "Choisir/Remplacer"
+          appartient au form d'upload via l'attribut `form`, le bouton
+          "Supprimer" appartient au form de suppression. HTML valide, pas
+          de soumission croisée possible. Le file input déclenche
+          `requestSubmit()` sur le form d'upload après validation client.
+        */}
         <form
           ref={formRef}
+          id="avatar-upload-form"
           action={uploadAction}
-          className="flex flex-col gap-2"
+          className="contents"
         >
           <input type="hidden" name="locale" value={locale} />
           <input
@@ -101,37 +109,43 @@ export function AvatarUploader({
               formRef.current?.requestSubmit();
             }}
           />
-
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              variant="outline"
-              disabled={uploadPending || removePending}
-              onClick={() => fileRef.current?.click()}
-              className="min-h-[44px] border-2 border-foreground px-5 font-mono text-xs uppercase tracking-widest"
-            >
-              {uploadPending
-                ? t('avatar.uploading')
-                : previewUrl
-                  ? t('avatar.replace')
-                  : t('avatar.pick')}
-            </Button>
-
-            {previewUrl && (
-              <form action={removeAction}>
-                <input type="hidden" name="locale" value={locale} />
-                <Button
-                  type="submit"
-                  variant="ghost"
-                  disabled={uploadPending || removePending}
-                  className="min-h-[44px] px-3 font-mono text-xs uppercase tracking-widest"
-                >
-                  {removePending ? t('avatar.removing') : t('avatar.remove')}
-                </Button>
-              </form>
-            )}
-          </div>
         </form>
+
+        <form
+          id="avatar-remove-form"
+          action={removeAction}
+          className="contents"
+        >
+          <input type="hidden" name="locale" value={locale} />
+        </form>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={uploadPending || removePending}
+            onClick={() => fileRef.current?.click()}
+            className="min-h-[44px] border-2 border-foreground px-5 font-mono text-xs uppercase tracking-widest"
+          >
+            {uploadPending
+              ? t('avatar.uploading')
+              : previewUrl
+                ? t('avatar.replace')
+                : t('avatar.pick')}
+          </Button>
+
+          {previewUrl && (
+            <Button
+              type="submit"
+              form="avatar-remove-form"
+              variant="ghost"
+              disabled={uploadPending || removePending}
+              className="min-h-[44px] px-3 font-mono text-xs uppercase tracking-widest"
+            >
+              {removePending ? t('avatar.removing') : t('avatar.remove')}
+            </Button>
+          )}
+        </div>
 
         <p className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
           {t('avatar.help')}

--- a/src/app/[locale]/profile/avatar-uploader.tsx
+++ b/src/app/[locale]/profile/avatar-uploader.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useActionState, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { Avatar } from '@/components/avatar';
+import { Button } from '@/components/ui/button';
+import {
+  AVATAR_MAX_BYTES,
+  AVATAR_MIME_TYPES,
+  isAvatarMimeType,
+} from '@/lib/profile/avatar';
+
+import {
+  removeAvatar,
+  uploadAvatar,
+  type AvatarState,
+} from './actions';
+
+const initial: AvatarState = { status: 'idle' };
+
+interface AvatarUploaderProps {
+  locale: string;
+  displayName: string;
+  initialAvatarUrl: string | null;
+}
+
+export function AvatarUploader({
+  locale,
+  displayName,
+  initialAvatarUrl,
+}: AvatarUploaderProps) {
+  const t = useTranslations('profile');
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const [clientError, setClientError] = useState<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(initialAvatarUrl);
+
+  const [uploadState, uploadAction, uploadPending] = useActionState(
+    uploadAvatar,
+    initial,
+  );
+  const [removeState, removeAction, removePending] = useActionState(
+    removeAvatar,
+    initial,
+  );
+
+  // Sync preview après succès server
+  useEffect(() => {
+    if (uploadState.status === 'success') {
+      setPreviewUrl(uploadState.avatarUrl ?? null);
+      setClientError(null);
+    }
+  }, [uploadState]);
+  useEffect(() => {
+    if (removeState.status === 'success') {
+      setPreviewUrl(null);
+      setClientError(null);
+    }
+  }, [removeState]);
+
+  const serverError =
+    uploadState.status === 'error' ? uploadState.error :
+    removeState.status === 'error' ? removeState.error :
+    null;
+
+  return (
+    <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-8">
+      <Avatar src={previewUrl} displayName={displayName} size="xl" />
+
+      <div className="flex flex-col gap-3">
+        <form
+          ref={formRef}
+          action={uploadAction}
+          className="flex flex-col gap-2"
+        >
+          <input type="hidden" name="locale" value={locale} />
+          <input
+            ref={fileRef}
+            type="file"
+            name="avatar"
+            accept={AVATAR_MIME_TYPES.join(',')}
+            className="sr-only"
+            aria-label={t('avatar.pick')}
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (!f) return;
+
+              // Validation client (évite un aller-retour serveur)
+              if (f.size > AVATAR_MAX_BYTES) {
+                setClientError(t('errors.avatarTooLarge'));
+                e.target.value = '';
+                return;
+              }
+              if (!isAvatarMimeType(f.type)) {
+                setClientError(t('errors.avatarMimeType'));
+                e.target.value = '';
+                return;
+              }
+              setClientError(null);
+              formRef.current?.requestSubmit();
+            }}
+          />
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={uploadPending || removePending}
+              onClick={() => fileRef.current?.click()}
+              className="min-h-[44px] border-2 border-foreground px-5 font-mono text-xs uppercase tracking-widest"
+            >
+              {uploadPending
+                ? t('avatar.uploading')
+                : previewUrl
+                  ? t('avatar.replace')
+                  : t('avatar.pick')}
+            </Button>
+
+            {previewUrl && (
+              <form action={removeAction}>
+                <input type="hidden" name="locale" value={locale} />
+                <Button
+                  type="submit"
+                  variant="ghost"
+                  disabled={uploadPending || removePending}
+                  className="min-h-[44px] px-3 font-mono text-xs uppercase tracking-widest"
+                >
+                  {removePending ? t('avatar.removing') : t('avatar.remove')}
+                </Button>
+              </form>
+            )}
+          </div>
+        </form>
+
+        <p className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+          {t('avatar.help')}
+        </p>
+
+        {clientError && (
+          <p role="alert" className="text-sm font-medium text-destructive">
+            {clientError}
+          </p>
+        )}
+        {!clientError && serverError && (
+          <p role="alert" className="text-sm font-medium text-destructive">
+            {t(serverError.replace('profile.', '') as 'errors.generic')}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -1,0 +1,98 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+import { requireUser } from '@/lib/auth';
+import { getProfile } from '@/lib/profile';
+
+import { signOut } from '../actions';
+import { ProfileForm } from './profile-form';
+
+interface ProfilePageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: ProfilePageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  const t = await getTranslations({ locale: typedLocale, namespace: 'profile' });
+  return {
+    title: t('metaTitle'),
+    description: t('metaDescription'),
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function ProfilePage({ params }: ProfilePageProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+
+  const user = await requireUser(typedLocale);
+  const profile = await getProfile();
+  const t = await getTranslations({ locale: typedLocale, namespace: 'profile' });
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16">
+      <header className="mb-12 flex items-start justify-between gap-4">
+        <div>
+          <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+            {t('eyebrow')}
+          </p>
+          <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
+            {t('title')}
+          </h1>
+          <p className="mt-3 text-base text-muted-foreground">
+            {t('lede', { email: user.email ?? '' })}
+          </p>
+        </div>
+        <form action={signOut}>
+          <input type="hidden" name="locale" value={typedLocale} />
+          <button
+            type="submit"
+            className="min-h-[44px] border border-border px-4 py-2 font-mono text-xs uppercase tracking-widest text-foreground transition hover:bg-muted"
+          >
+            {t('logout')}
+          </button>
+        </form>
+      </header>
+
+      <section className="border-2 border-foreground p-8">
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('section.label')}
+        </p>
+        <h2 className="mt-3 mb-6 font-display text-2xl leading-snug text-foreground">
+          {t('section.heading')}
+        </h2>
+
+        <ProfileForm
+          locale={typedLocale}
+          initialPseudo={profile?.pseudo ?? null}
+          initialFullName={profile?.full_name ?? null}
+        />
+      </section>
+
+      <nav className="mt-10 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
+        <Link
+          href={`/${typedLocale}/dashboard`}
+          className="underline-offset-4 hover:underline"
+        >
+          ← {t('nav.dashboard')}
+        </Link>
+        <Link
+          href={`/${typedLocale}`}
+          className="underline-offset-4 hover:underline"
+        >
+          {t('nav.home')}
+        </Link>
+      </nav>
+    </main>
+  );
+}

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -43,19 +43,19 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-16">
-      <header className="mb-12 flex items-start justify-between gap-4">
-        <div>
+      <header className="mb-12 flex flex-col items-start gap-6 sm:flex-row sm:justify-between sm:gap-4">
+        <div className="min-w-0">
           <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
             {t('eyebrow')}
           </p>
-          <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
+          <h1 className="mt-3 font-display text-4xl leading-tight text-foreground break-words sm:text-5xl">
             {t('title')}
           </h1>
-          <p className="mt-3 text-base text-muted-foreground">
+          <p className="mt-3 break-words text-base text-muted-foreground">
             {t('lede', { email: user.email ?? '' })}
           </p>
         </div>
-        <form action={signOut}>
+        <form action={signOut} className="shrink-0">
           <input type="hidden" name="locale" value={typedLocale} />
           <button
             type="submit"
@@ -99,13 +99,13 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
       <nav className="mt-10 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
         <Link
           href={`/${typedLocale}/dashboard`}
-          className="underline-offset-4 hover:underline"
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
         >
           ← {t('nav.dashboard')}
         </Link>
         <Link
           href={`/${typedLocale}`}
-          className="underline-offset-4 hover:underline"
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
         >
           {t('nav.home')}
         </Link>

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -4,9 +4,10 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LOCALES, type Locale } from '@/i18n/request';
 import { requireUser } from '@/lib/auth';
-import { getProfile } from '@/lib/profile';
+import { getDisplayName, getProfile } from '@/lib/profile';
 
 import { signOut } from '../actions';
+import { AvatarUploader } from './avatar-uploader';
 import { ProfileForm } from './profile-form';
 
 interface ProfilePageProps {
@@ -37,6 +38,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
 
   const user = await requireUser(typedLocale);
   const profile = await getProfile();
+  const displayName = getDisplayName(profile, user);
   const t = await getTranslations({ locale: typedLocale, namespace: 'profile' });
 
   return (
@@ -63,6 +65,21 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           </button>
         </form>
       </header>
+
+      <section className="mb-8 border-2 border-foreground p-8">
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('avatar.label')}
+        </p>
+        <h2 className="mt-3 mb-6 font-display text-2xl leading-snug text-foreground">
+          {t('avatar.heading')}
+        </h2>
+
+        <AvatarUploader
+          locale={typedLocale}
+          displayName={displayName}
+          initialAvatarUrl={profile?.avatar_url ?? null}
+        />
+      </section>
 
       <section className="border-2 border-foreground p-8">
         <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">

--- a/src/app/[locale]/profile/profile-form.tsx
+++ b/src/app/[locale]/profile/profile-form.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useActionState, useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+import { updateProfile, type ProfileState } from './actions';
+
+const initial: ProfileState = { status: 'idle' };
+
+interface ProfileFormProps {
+  locale: string;
+  initialPseudo: string | null;
+  initialFullName: string | null;
+}
+
+export function ProfileForm({
+  locale,
+  initialPseudo,
+  initialFullName,
+}: ProfileFormProps) {
+  const t = useTranslations('profile');
+  const [state, action, pending] = useActionState(updateProfile, initial);
+  const successRef = useRef<HTMLParagraphElement | null>(null);
+
+  // Petit focus management : on annonce la réussite.
+  useEffect(() => {
+    if (state.status === 'success' && successRef.current) {
+      successRef.current.focus();
+    }
+  }, [state.status]);
+
+  return (
+    <form action={action} noValidate className="flex flex-col gap-6">
+      <input type="hidden" name="locale" value={locale} />
+
+      <div className="flex flex-col gap-2">
+        <Label
+          htmlFor="pseudo"
+          className="font-mono text-xs uppercase tracking-widest"
+        >
+          {t('form.pseudo.label')}
+        </Label>
+        <Input
+          id="pseudo"
+          name="pseudo"
+          type="text"
+          autoComplete="username"
+          inputMode="text"
+          defaultValue={initialPseudo ?? ''}
+          minLength={3}
+          maxLength={30}
+          pattern="[a-z0-9_]{3,30}"
+          aria-invalid={state.status === 'error' && state.field === 'pseudo'}
+          aria-describedby="pseudo-help"
+          placeholder={t('form.pseudo.placeholder')}
+          className="min-h-[48px] border-2 border-foreground text-base"
+        />
+        <p
+          id="pseudo-help"
+          className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground"
+        >
+          {t('form.pseudo.help')}
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label
+          htmlFor="full_name"
+          className="font-mono text-xs uppercase tracking-widest"
+        >
+          {t('form.fullName.label')}
+        </Label>
+        <Input
+          id="full_name"
+          name="full_name"
+          type="text"
+          autoComplete="name"
+          defaultValue={initialFullName ?? ''}
+          maxLength={50}
+          aria-invalid={state.status === 'error' && state.field === 'full_name'}
+          aria-describedby="full-name-help"
+          placeholder={t('form.fullName.placeholder')}
+          className="min-h-[48px] border-2 border-foreground text-base"
+        />
+        <p
+          id="full-name-help"
+          className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground"
+        >
+          {t('form.fullName.help')}
+        </p>
+      </div>
+
+      {state.status === 'error' && state.error && (
+        <p role="alert" className="text-sm font-medium text-destructive">
+          {t(state.error.replace('profile.', '') as 'errors.generic')}
+        </p>
+      )}
+
+      {state.status === 'success' && (
+        <p
+          ref={successRef}
+          role="status"
+          tabIndex={-1}
+          className="text-sm font-medium text-foreground"
+          style={{ color: 'var(--color-acid, currentColor)' }}
+        >
+          {t('form.saved')}
+        </p>
+      )}
+
+      <Button
+        type="submit"
+        disabled={pending}
+        className="min-h-[48px] w-full bg-foreground text-base font-medium text-background hover:bg-foreground/90 sm:w-auto sm:self-start sm:px-8"
+      >
+        {pending ? t('form.submitPending') : t('form.submit')}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -22,6 +22,12 @@ interface AvatarProps {
   size?: Size;
   /** Classe Tailwind additionnelle. */
   className?: string;
+  /**
+   * Si l'avatar est accolé à un texte qui nomme déjà la personne (ex. pseudo
+   * dans un même `<Link>`), passer `decorative` pour éviter la duplication
+   * pour les lecteurs d'écran.
+   */
+  decorative?: boolean;
 }
 
 /**
@@ -36,6 +42,7 @@ export function Avatar({
   displayName,
   size = 'md',
   className = '',
+  decorative = false,
 }: AvatarProps) {
   const px = SIZE_PX[size];
   const initials = initialsFor(displayName);
@@ -51,11 +58,15 @@ export function Avatar({
 
   if (src) {
     return (
-      <span className={`${base} ${className}`.trim()} style={style}>
+      <span
+        className={`${base} ${className}`.trim()}
+        style={style}
+        {...(decorative ? { 'aria-hidden': true } : {})}
+      >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={src}
-          alt={displayName}
+          alt={decorative ? '' : displayName}
           width={px}
           height={px}
           loading="lazy"
@@ -70,7 +81,9 @@ export function Avatar({
     <span
       className={`${base} ${SIZE_TEXT[size]} ${className}`.trim()}
       style={style}
-      aria-label={displayName}
+      {...(decorative
+        ? { 'aria-hidden': true }
+        : { 'aria-label': displayName })}
     >
       {initials}
     </span>

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -1,0 +1,78 @@
+import { initialsFor } from '@/lib/profile/avatar';
+
+type Size = 'sm' | 'md' | 'lg' | 'xl';
+
+const SIZE_PX: Record<Size, number> = {
+  sm: 32,
+  md: 44,
+  lg: 64,
+  xl: 112,
+};
+
+const SIZE_TEXT: Record<Size, string> = {
+  sm: 'text-[11px]',
+  md: 'text-sm',
+  lg: 'text-base',
+  xl: 'text-2xl',
+};
+
+interface AvatarProps {
+  src: string | null | undefined;
+  displayName: string;
+  size?: Size;
+  /** Classe Tailwind additionnelle. */
+  className?: string;
+}
+
+/**
+ * Avatar carré à coins droits (cohérent avec la direction brutaliste du v2).
+ * Fallback initiales sur fond "paper" + bordure "ink" si pas d'image.
+ *
+ * Pour une image optimisée Next.js, on utilisera `<Image />` plus tard ;
+ * pour l'instant `<img>` suffit (avatars Supabase publics, cache-buster).
+ */
+export function Avatar({
+  src,
+  displayName,
+  size = 'md',
+  className = '',
+}: AvatarProps) {
+  const px = SIZE_PX[size];
+  const initials = initialsFor(displayName);
+  const base =
+    'inline-flex shrink-0 items-center justify-center overflow-hidden border-2 font-mono uppercase tracking-widest';
+  const style: React.CSSProperties = {
+    width: px,
+    height: px,
+    borderColor: 'var(--color-foreground)',
+    background: 'var(--color-muted, var(--color-background))',
+    color: 'var(--color-foreground)',
+  };
+
+  if (src) {
+    return (
+      <span className={`${base} ${className}`.trim()} style={style}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={src}
+          alt={displayName}
+          width={px}
+          height={px}
+          loading="lazy"
+          decoding="async"
+          className="h-full w-full object-cover"
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`${base} ${SIZE_TEXT[size]} ${className}`.trim()}
+      style={style}
+      aria-label={displayName}
+    >
+      {initials}
+    </span>
+  );
+}

--- a/src/components/icons/google.tsx
+++ b/src/components/icons/google.tsx
@@ -1,0 +1,31 @@
+/**
+ * Logo Google officiel — utilisé pour le bouton "Continuer avec Google".
+ * Conforme aux brand guidelines Google Identity.
+ */
+export function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+    >
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+      />
+      <path
+        fill="#FBBC05"
+        d="M5.84 14.1c-.22-.66-.35-1.36-.35-2.1s.13-1.44.35-2.1V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.61z"
+      />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z"
+      />
+    </svg>
+  );
+}

--- a/src/components/scroll-to-top.tsx
+++ b/src/components/scroll-to-top.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+export function ScrollToTop() {
+  const t = useTranslations('common');
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <button
+      type="button"
+      aria-label={t('scrollToTop')}
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      className={[
+        'fixed bottom-6 right-6 z-50 inline-flex h-12 w-12 items-center justify-center rounded-full transition-all duration-200',
+        'border-2 hover:-translate-y-[2px]',
+        visible
+          ? 'pointer-events-auto opacity-100'
+          : 'pointer-events-none opacity-0',
+      ].join(' ')}
+      style={{
+        background: 'var(--color-brand)',
+        color: 'var(--color-primary-foreground)',
+        borderColor: 'var(--color-foreground)',
+        boxShadow: 'var(--shadow-glow)',
+      }}
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        className="h-5 w-5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="square"
+        strokeLinejoin="miter"
+      >
+        <path d="M12 19V5M5 12l7-7 7 7" />
+      </svg>
+    </button>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -54,19 +54,108 @@
     }
   },
   "home": {
+    "eyebrow": "IRONTRACK · 2026 · MADE IN BELGIUM",
     "hero": {
-      "eyebrow": "Masterclass redesign",
+      "kicker": "The workshop notebook for your training",
       "train": "Train",
       "heavier": "heavier,",
       "live": "live",
       "lighter": "lighter.",
-      "lede": "A fitness app built like a workshop notebook: precise, editorial, brutalist. No confetti. No jargon. Just your body, your numbers, your progress."
+      "lede": "Track every rep, every watt, every calorie. No bullshit. No ads. No empty gamification. Just your numbers and your progress.",
+      "cta": {
+        "start": "Create my free account",
+        "discover": "Discover",
+        "dashboard": "My dashboard"
+      }
+    },
+    "features": {
+      "eyebrow": "WHAT YOU GET",
+      "heading": "Everything needed.",
+      "headingAccent": "Nothing extra.",
+      "logging": {
+        "tag": "01 · SESSIONS",
+        "title": "Log every rep, every set.",
+        "body": "Strength and cardio in a single app. Sets, reps, weight, RPE. For the rower: SPM, watts. For running: pace, elevation. Live mode with rest timer.",
+        "bullet1": "Dynamic sets",
+        "bullet2": "Advanced cardio",
+        "bullet3": "Live mode"
+      },
+      "progress": {
+        "tag": "02 · PROGRESS",
+        "title": "See where you're going.",
+        "body": "Charts of estimated 1RM, weekly volume, frequency per muscle group. Compare your cycles. Spot plateaus before they settle in.",
+        "bullet1": "Estimated 1RM",
+        "bullet2": "Weekly volume",
+        "bullet3": "Personal records"
+      },
+      "nutrition": {
+        "tag": "03 · BE NUTRITION",
+        "title": "Count macros. The Belgian way.",
+        "body": "Scan the barcode of your Colruyt, Delhaize or Carrefour product. Nutri-Score, macros, ingredients. Open Food Facts (3M+ products) at the core.",
+        "bullet1": "Barcode scan",
+        "bullet2": "Nutri-Score",
+        "bullet3": "BE products"
+      },
+      "coach": {
+        "tag": "04 · AI COACH",
+        "title": "A coach that listens.",
+        "body": "Plans adapted to your equipment, your time, your goals. Tips on plateaus. No guilt-tripping, no anxiety-inducing alerts.",
+        "bullet1": "Adapted plans",
+        "bullet2": "Anti-plateau",
+        "bullet3": "Zero pressure"
+      }
+    },
+    "how": {
+      "eyebrow": "IN 3 STEPS",
+      "heading": "How it works.",
+      "log": {
+        "title": "You log your session.",
+        "body": "During or after, doesn't matter. A few taps and it's done. The app remembers everything: your last weight, your last reps, your records."
+      },
+      "track": {
+        "title": "The app remembers everything.",
+        "body": "Your data stays yours (GDPR-first, hosted in Europe). Multi-device sync. Full export whenever you want."
+      },
+      "progress": {
+        "title": "You see your progress.",
+        "body": "No vanity metrics. Just what matters: volume, intensity, frequency, sleep, nutrition. You decide what to change."
+      }
+    },
+    "vs": {
+      "eyebrow": "POSITIONING",
+      "heading": "Why not",
+      "headingAccent": "Hevy, Strava or Whoop ?",
+      "lede": "Each app excels in its lane. IronTrack bridges them: serious strength training, precise cardio, Belgian nutrition — without forced subscription or ads.",
+      "feature": "Feature",
+      "rows": {
+        "logging": "Detailed strength training",
+        "cardio": "Cardio (rower, bike, running)",
+        "nutrition": "Nutrition + barcode scan",
+        "belgian": "Belgian products natively",
+        "noads": "Ad-free",
+        "opensource": "Open source"
+      },
+      "disclaimer": "* Comparison based on public free tiers as of April 2026"
+    },
+    "manifesto": {
+      "eyebrow": "MANIFESTO",
+      "quote": "\"The iron never lies. Neither do your numbers.\"",
+      "body": "We've seen too many fitness apps that turn training into a video game, guilt-trip you for missing a session, or sell your data. IronTrack does the opposite: a sober, precise tool that respects you.",
+      "cta": {
+        "start": "Create my free account",
+        "dashboard": "My dashboard"
+      }
     },
     "cta": {
-      "start": "Start the session",
+      "start": "Create my free account",
       "login": "Sign in",
       "dashboard": "My dashboard",
       "logout": "Sign out"
+    },
+    "footer": {
+      "copyright": "© IronTrack 2026 · Made in Belgium",
+      "quote": "\"The iron never lies.\"",
+      "build": "Build · v2.0.0-alpha"
     },
     "greeting": "Signed in as {email}"
   },
@@ -116,7 +205,8 @@
     },
     "checkEmail": {
       "title": "Check your inbox.",
-      "body": "If the address is valid, you'll receive a link in a few seconds. Don't forget to check spam."
+      "body": "If the address is valid, you'll receive a link in a few seconds. Don't forget to check spam.",
+      "hint": "The link may open in a new tab (Gmail, Outlook). No worries: this tab will update automatically as soon as you're signed in."
     },
     "errors": {
       "emailRequired": "Email is required.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -62,7 +62,24 @@
       "lighter": "lighter.",
       "lede": "A fitness app built like a workshop notebook: precise, editorial, brutalist. No confetti. No jargon. Just your body, your numbers, your progress."
     },
-    "cta": { "start": "Start the session", "login": "Sign in" }
+    "cta": {
+      "start": "Start the session",
+      "login": "Sign in",
+      "dashboard": "My dashboard",
+      "logout": "Sign out"
+    },
+    "greeting": "Signed in as {email}"
+  },
+  "dashboard": {
+    "eyebrow": "DASHBOARD",
+    "title": "Welcome.",
+    "greeting": "Signed in as {email}.",
+    "logout": "Sign out",
+    "back": "Back to home",
+    "placeholder": {
+      "label": "COMING NEXT",
+      "body": "The real dashboard is on its way: your last session, your records, your upcoming sessions, your progress graphs."
+    }
   },
   "langSwitcher": {
     "label": "Choose language",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -163,12 +163,60 @@
   "dashboard": {
     "eyebrow": "DASHBOARD",
     "title": "Welcome.",
+    "hello": "Welcome, {name}.",
     "greeting": "Signed in as {email}.",
     "logout": "Sign out",
     "back": "Back to home",
+    "profileLink": "My profile",
+    "onboarding": {
+      "label": "COMPLETE YOUR PROFILE",
+      "body": "Pick a username to personalise your space — and, later, train alongside partners.",
+      "cta": "Complete my profile"
+    },
     "placeholder": {
       "label": "COMING NEXT",
       "body": "The real dashboard is on its way: your last session, your records, your upcoming sessions, your progress graphs."
+    }
+  },
+  "profile": {
+    "metaTitle": "My profile",
+    "metaDescription": "Manage your IronTrack username and display name.",
+    "eyebrow": "PROFILE",
+    "title": "You, in numbers.",
+    "lede": "Signed in as {email}. You can change your username and display name at any time.",
+    "logout": "Sign out",
+    "section": {
+      "label": "IDENTITY",
+      "heading": "How should we call you?"
+    },
+    "form": {
+      "pseudo": {
+        "label": "Username",
+        "placeholder": "my_handle",
+        "help": "3-30 chars · lowercase, digits, underscore · used to find you between partners."
+      },
+      "fullName": {
+        "label": "Display name",
+        "placeholder": "Thierry V.",
+        "help": "Up to 50 chars · shown on your dashboard."
+      },
+      "submit": "Save",
+      "submitPending": "Saving…",
+      "saved": "Profile updated."
+    },
+    "errors": {
+      "pseudoTooShort": "Username too short (3 chars min).",
+      "pseudoTooLong": "Username too long (30 chars max).",
+      "pseudoFormat": "Only lowercase letters, digits and underscore allowed.",
+      "pseudoTaken": "This username is already taken.",
+      "fullNameRequired": "Enter a name or leave empty.",
+      "fullNameTooLong": "Name too long (50 chars max).",
+      "rateLimit": "Too many attempts. Try again in a minute.",
+      "generic": "Something went wrong. Try again."
+    },
+    "nav": {
+      "dashboard": "Dashboard",
+      "home": "Home"
     }
   },
   "langSwitcher": {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -195,12 +195,26 @@
       "google": "Continue with Google",
       "or": "OR BY EMAIL"
     },
+    "tabs": {
+      "label": "Sign-in method",
+      "password": "Email + password",
+      "magic": "Magic link"
+    },
     "form": {
       "email": {
         "label": "Email",
         "placeholder": "you@example.com"
       },
+      "password": {
+        "label": "Password",
+        "placeholder": "At least 10 characters",
+        "help": "10 chars min · 1 uppercase · 1 digit"
+      },
       "submit": "Send the link",
+      "signin": "Sign in",
+      "signup": "Create account",
+      "toSignup": "No account yet? Create one",
+      "toSignin": "Already have an account? Sign in",
       "submitPending": "Sending…",
       "hint": "By continuing, you accept our terms and privacy policy (GDPR)."
     },
@@ -212,6 +226,11 @@
     "errors": {
       "emailRequired": "Email is required.",
       "emailInvalid": "This email address is not valid.",
+      "passwordTooShort": "Password too short (10 characters min).",
+      "passwordTooLong": "Password too long (72 characters max).",
+      "passwordWeak": "Add at least one uppercase, one lowercase and one digit.",
+      "invalidCredentials": "Wrong email or password.",
+      "emailTaken": "An account already exists with this email. Sign in.",
       "rateLimit": "Too many attempts. Try again in a minute.",
       "generic": "Something went wrong. Try again."
     },

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -208,7 +208,7 @@
       "password": {
         "label": "Password",
         "placeholder": "At least 10 characters",
-        "help": "10 chars min · 1 uppercase · 1 digit"
+        "help": "10 chars · 1 uppercase · 1 digit · 1 special (!@#…)"
       },
       "submit": "Send the link",
       "signin": "Sign in",
@@ -228,7 +228,7 @@
       "emailInvalid": "This email address is not valid.",
       "passwordTooShort": "Password too short (10 characters min).",
       "passwordTooLong": "Password too long (72 characters max).",
-      "passwordWeak": "Add at least one uppercase, one lowercase and one digit.",
+      "passwordWeak": "Add at least one uppercase, one lowercase, one digit and one special character (!@#$…).",
       "invalidCredentials": "Wrong email or password.",
       "emailTaken": "An account already exists with this email. Sign in.",
       "rateLimit": "Too many attempts. Try again in a minute.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -185,6 +185,16 @@
     "title": "You, in numbers.",
     "lede": "Signed in as {email}. You can change your username and display name at any time.",
     "logout": "Sign out",
+    "avatar": {
+      "label": "PHOTO",
+      "heading": "Your profile picture.",
+      "pick": "Pick a photo",
+      "replace": "Replace photo",
+      "remove": "Remove",
+      "uploading": "Uploading…",
+      "removing": "Removing…",
+      "help": "JPG, PNG, WebP or GIF · 5 MB max · square recommended."
+    },
     "section": {
       "label": "IDENTITY",
       "heading": "How should we call you?"
@@ -211,6 +221,9 @@
       "pseudoTaken": "This username is already taken.",
       "fullNameRequired": "Enter a name or leave empty.",
       "fullNameTooLong": "Name too long (50 chars max).",
+      "avatarTooLarge": "Image too large (5 MB max).",
+      "avatarMimeType": "Unsupported format. JPG, PNG, WebP or GIF.",
+      "avatarUpload": "Upload failed. Try again.",
       "rateLimit": "Too many attempts. Try again in a minute.",
       "generic": "Something went wrong. Try again."
     },

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -300,5 +300,57 @@
       "body": "This magic link no longer works. Request a new one.",
       "cta": "Send a new link"
     }
+  },
+  "legal": {
+    "eyebrow": "LEGAL · IRONTRACK",
+    "nav": {
+      "home": "Home",
+      "privacy": "Privacy",
+      "terms": "Terms"
+    },
+    "draft": {
+      "label": "DRAFT · v2 ALPHA",
+      "body": "This page is a working draft. The final version will be published before v1.0 and will comply with the GDPR (Belgium, EU)."
+    },
+    "privacy": {
+      "title": "Privacy policy.",
+      "lede": "Your data stays yours. IronTrack is hosted in Europe and built GDPR-first.",
+      "collect": {
+        "title": "What we collect",
+        "body": "Strictly the essentials: your email, your training sessions, your metrics. No ad tracking, no third-party analytics. Your avatar is stored in our Supabase Storage in Europe."
+      },
+      "usage": {
+        "title": "How we use it",
+        "body": "To display your progress, sync your sessions between your devices, and secure your account. Never sold. Never shared with third parties for marketing purposes."
+      },
+      "rights": {
+        "title": "Your rights (GDPR)",
+        "body": "Access, correction, deletion, full export, portability. Write to us and we reply within 30 days."
+      },
+      "contact": {
+        "title": "Contact",
+        "body": "privacy@irontrack.app — IronTrack, Belgium."
+      }
+    },
+    "terms": {
+      "title": "Terms of service.",
+      "lede": "The rules of the game. Plain language, no dark patterns.",
+      "service": {
+        "title": "The service",
+        "body": "IronTrack is a training, progress and nutrition tracker. Free during the alpha. Paid plans will be announced transparently, no auto-enrolment."
+      },
+      "account": {
+        "title": "Your account",
+        "body": "You are responsible for your password. Report any abuse to us. We may suspend an account in case of abuse (bot, scraping, violation)."
+      },
+      "content": {
+        "title": "Your content",
+        "body": "You own your data. You can export or delete it at any time. We only use it to make the product work for you."
+      },
+      "liability": {
+        "title": "Liability",
+        "body": "IronTrack is not medical advice. Consult a healthcare professional before any intensive programme. The service is provided \"as is\" during the alpha phase."
+      }
+    }
   }
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1,5 +1,6 @@
 {
   "brand": { "name": "IronTrack", "tagline": "Train heavier, live lighter." },
+  "common": { "scrollToTop": "Back to top" },
   "nav": {
     "home": "Home",
     "workouts": "Sessions",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -74,9 +74,19 @@
     "login": {
       "metaTitle": "Sign in · IronTrack",
       "metaDescription": "Sign in to IronTrack with a magic link. No password required.",
-      "eyebrow": "ACCESS · MAGIC LINK",
-      "title": "Sign in.",
-      "lede": "No password. We email you a secure link."
+      "eyebrow": "ACCESS · IRONTRACK",
+      "title": "Welcome back.",
+      "lede": "Sign in with Google or get a magic link by email. No password to remember.",
+      "editorialKicker": "MANIFESTO · 01",
+      "editorialQuote": "\"The iron never lies. Neither do your numbers.\"",
+      "editorialAttribution": "A fitness app built like a workshop notebook. No empty gamification, no anxiety-driven notifications. Just your data, your progress, your routine.",
+      "terms": "By continuing, you accept our",
+      "privacy": "Privacy policy",
+      "termsLink": "Terms of service"
+    },
+    "oauth": {
+      "google": "Continue with Google",
+      "or": "OR BY EMAIL"
     },
     "form": {
       "email": {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -179,11 +179,11 @@
   },
   "auth": {
     "login": {
-      "metaTitle": "Sign in · IronTrack",
-      "metaDescription": "Sign in to IronTrack with a magic link. No password required.",
+      "metaTitle": "Sign in",
+      "metaDescription": "Sign in to IronTrack with Google or with your email and password.",
       "eyebrow": "ACCESS · IRONTRACK",
       "title": "Welcome back.",
-      "lede": "Sign in with Google or get a magic link by email. No password to remember.",
+      "lede": "Sign in with Google or with your email. That's it.",
       "editorialKicker": "MANIFESTO · 01",
       "editorialQuote": "\"The iron never lies. Neither do your numbers.\"",
       "editorialAttribution": "A fitness app built like a workshop notebook. No empty gamification, no anxiety-driven notifications. Just your data, your progress, your routine.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -54,19 +54,108 @@
     }
   },
   "home": {
+    "eyebrow": "IRONTRACK · 2026 · MADE IN BELGIUM",
     "hero": {
-      "eyebrow": "Masterclass redesign",
+      "kicker": "Le carnet d'atelier de ton entraînement",
       "train": "Train",
       "heavier": "heavier,",
       "live": "live",
       "lighter": "lighter.",
-      "lede": "Une app fitness pensée comme un carnet d'atelier : précise, éditoriale, brutaliste. Pas de confettis. Pas de jargon. Juste ton corps, tes chiffres, ton progrès."
+      "lede": "Suis chaque rep, chaque watt, chaque calorie. Sans bullshit. Sans pub. Sans gamification creuse. Juste tes chiffres et ta progression.",
+      "cta": {
+        "start": "Créer mon compte gratuit",
+        "discover": "Découvrir",
+        "dashboard": "Mon tableau de bord"
+      }
+    },
+    "features": {
+      "eyebrow": "CE QUE TU OBTIENS",
+      "heading": "Tout ce qu'il faut.",
+      "headingAccent": "Rien de superflu.",
+      "logging": {
+        "tag": "01 · SÉANCES",
+        "title": "Logue chaque rep, chaque set.",
+        "body": "Musculation et cardio dans une seule app. Sets, reps, poids, RPE. Pour le rameur : SPM, watts. Pour la course : pace, dénivelé. Mode live avec timer de repos.",
+        "bullet1": "Sets dynamiques",
+        "bullet2": "Métriques cardio avancées",
+        "bullet3": "Mode live"
+      },
+      "progress": {
+        "tag": "02 · PROGRESSION",
+        "title": "Vois où tu vas. Vraiment.",
+        "body": "Graphes de 1RM estimé, volume hebdo, fréquence par groupe musculaire. Compare tes cycles. Identifie tes plateaux avant qu'ils s'installent.",
+        "bullet1": "1RM estimé",
+        "bullet2": "Volume hebdo",
+        "bullet3": "Records perso"
+      },
+      "nutrition": {
+        "tag": "03 · NUTRITION BE",
+        "title": "Compte tes macros. En belge.",
+        "body": "Scanne le code-barres de ton produit Colruyt, Delhaize ou Carrefour. Nutri-Score, macros, ingrédients. Open Food Facts (3M+ produits) en base.",
+        "bullet1": "Scan code-barres",
+        "bullet2": "Nutri-Score",
+        "bullet3": "Produits BE"
+      },
+      "coach": {
+        "tag": "04 · COACH IA",
+        "title": "Un coach qui t'écoute.",
+        "body": "Plans adaptés à ton équipement, ton temps, tes objectifs. Conseils sur tes plateaux. Sans culpabilisation, sans alertes anxiogènes.",
+        "bullet1": "Plans adaptés",
+        "bullet2": "Anti-plateau",
+        "bullet3": "Zéro pression"
+      }
+    },
+    "how": {
+      "eyebrow": "EN 3 ÉTAPES",
+      "heading": "Comment ça marche.",
+      "log": {
+        "title": "Tu logues ta séance.",
+        "body": "Pendant ou après, peu importe. Quelques tap, c'est fait. L'app retient tout : ton dernier poids, tes derniers reps, tes records."
+      },
+      "track": {
+        "title": "L'app retient tout.",
+        "body": "Tes données restent à toi (RGPD-first, hébergement Europe). Synchro multi-appareils. Export complet quand tu veux."
+      },
+      "progress": {
+        "title": "Tu vois ta progression.",
+        "body": "Pas de vanity metrics. Juste ce qui compte : volume, intensité, fréquence, sommeil, alimentation. Tu décides quoi changer."
+      }
+    },
+    "vs": {
+      "eyebrow": "POSITIONNEMENT",
+      "heading": "Pourquoi pas",
+      "headingAccent": "Hevy, Strava ou Whoop ?",
+      "lede": "Chaque app excelle dans son couloir. IronTrack fait le pont : musculation sérieuse, cardio précis, nutrition belge, le tout sans abonnement obligatoire ni publicité.",
+      "feature": "Fonctionnalité",
+      "rows": {
+        "logging": "Musculation détaillée",
+        "cardio": "Cardio (rameur, vélo, course)",
+        "nutrition": "Nutrition + scan code-barres",
+        "belgian": "Produits belges natifs",
+        "noads": "Sans pub",
+        "opensource": "Code ouvert"
+      },
+      "disclaimer": "* Comparatif basé sur les versions gratuites publiques en avril 2026"
+    },
+    "manifesto": {
+      "eyebrow": "MANIFESTE",
+      "quote": "« Le fer ne ment jamais. Tes chiffres non plus. »",
+      "body": "On a vu trop d'apps fitness qui transforment ton entraînement en jeu vidéo, te culpabilisent quand tu sautes une séance, ou vendent tes données. IronTrack fait l'inverse : un outil sobre, précis, qui te respecte.",
+      "cta": {
+        "start": "Créer mon compte gratuit",
+        "dashboard": "Mon tableau de bord"
+      }
     },
     "cta": {
-      "start": "Commencer la séance",
+      "start": "Créer mon compte gratuit",
       "login": "Se connecter",
       "dashboard": "Mon tableau de bord",
       "logout": "Se déconnecter"
+    },
+    "footer": {
+      "copyright": "© IronTrack 2026 · Made in Belgium",
+      "quote": "\"The iron never lies.\"",
+      "build": "Build · v2.0.0-alpha"
     },
     "greeting": "Connecté en tant que {email}"
   },
@@ -116,7 +205,8 @@
     },
     "checkEmail": {
       "title": "Vérifie ta boîte mail.",
-      "body": "Si l'adresse est valide, tu recevras un lien dans quelques secondes. Pense à regarder dans les spams."
+      "body": "Si l'adresse est valide, tu recevras un lien dans quelques secondes. Pense à regarder dans les spams.",
+      "hint": "Le lien peut s'ouvrir dans un nouvel onglet (Gmail, Outlook). Pas grave : cet onglet-ci se mettra à jour automatiquement dès que tu seras connecté."
     },
     "errors": {
       "emailRequired": "L'email est obligatoire.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1,5 +1,6 @@
 {
   "brand": { "name": "IronTrack", "tagline": "Train heavier, live lighter." },
+  "common": { "scrollToTop": "Retour en haut" },
   "nav": {
     "home": "Accueil",
     "workouts": "Séances",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -208,7 +208,7 @@
       "password": {
         "label": "Mot de passe",
         "placeholder": "Au moins 10 caractères",
-        "help": "10 caractères min · 1 majuscule · 1 chiffre"
+        "help": "10 caractères · 1 majuscule · 1 chiffre · 1 spécial (!@#…)"
       },
       "submit": "Recevoir le lien",
       "signin": "Se connecter",
@@ -228,7 +228,7 @@
       "emailInvalid": "Cette adresse email n'est pas valide.",
       "passwordTooShort": "Mot de passe trop court (10 caractères min).",
       "passwordTooLong": "Mot de passe trop long (72 caractères max).",
-      "passwordWeak": "Ajoute au moins une majuscule, une minuscule et un chiffre.",
+      "passwordWeak": "Ajoute au moins une majuscule, une minuscule, un chiffre et un caractère spécial (!@#$…).",
       "invalidCredentials": "Email ou mot de passe incorrect.",
       "emailTaken": "Un compte existe déjà avec cet email. Connecte-toi.",
       "rateLimit": "Trop de tentatives. Réessaie dans une minute.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -185,6 +185,16 @@
     "title": "Toi, en chiffres.",
     "lede": "Connecté en tant que {email}. Tu peux changer ton pseudo et ton nom à tout moment.",
     "logout": "Se déconnecter",
+    "avatar": {
+      "label": "PHOTO",
+      "heading": "Ta photo de profil.",
+      "pick": "Choisir une photo",
+      "replace": "Remplacer la photo",
+      "remove": "Supprimer",
+      "uploading": "Envoi…",
+      "removing": "Suppression…",
+      "help": "JPG, PNG, WebP ou GIF · 5 Mo max · carré conseillé."
+    },
     "section": {
       "label": "IDENTITÉ",
       "heading": "Comment tu veux qu'on t'appelle ?"
@@ -211,6 +221,9 @@
       "pseudoTaken": "Ce pseudo est déjà pris.",
       "fullNameRequired": "Entre un nom ou laisse vide.",
       "fullNameTooLong": "Nom trop long (50 caractères max).",
+      "avatarTooLarge": "Image trop lourde (5 Mo max).",
+      "avatarMimeType": "Format non supporté. JPG, PNG, WebP ou GIF.",
+      "avatarUpload": "Impossible d'envoyer la photo. Réessaie.",
       "rateLimit": "Trop de tentatives. Réessaie dans une minute.",
       "generic": "Une erreur est survenue. Réessaie."
     },

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1,6 +1,11 @@
 {
-  "brand": { "name": "IronTrack", "tagline": "Train heavier, live lighter." },
-  "common": { "scrollToTop": "Retour en haut" },
+  "brand": {
+    "name": "IronTrack",
+    "tagline": "Train heavier, live lighter."
+  },
+  "common": {
+    "scrollToTop": "Retour en haut"
+  },
   "nav": {
     "home": "Accueil",
     "workouts": "Séances",
@@ -14,17 +19,29 @@
     "eyebrow": "IRONTRACK · v2 · 2026",
     "hero": {
       "kicker": "Masterclass redesign",
-      "train": "Train",
-      "heavier": "heavier,",
-      "live": "live",
-      "lighter": "lighter."
+      "train": "Soulève",
+      "heavier": "plus lourd,",
+      "live": "vis",
+      "lighter": "plus léger."
     },
     "lede": "Une app fitness pensée comme un carnet d'atelier : précise, éditoriale, brutaliste. Pas de confettis. Pas de jargon. Juste ton corps, tes chiffres, ton progrès.",
     "meta": {
-      "stack": { "label": "Stack", "value": "Next 16" },
-      "backend": { "label": "Backend", "value": "Supabase" },
-      "budget": { "label": "Budget", "value": "0 €" },
-      "target": { "label": "Cible", "value": "Hevy · Strava · Whoop" }
+      "stack": {
+        "label": "Stack",
+        "value": "Next 16"
+      },
+      "backend": {
+        "label": "Backend",
+        "value": "Supabase"
+      },
+      "budget": {
+        "label": "Budget",
+        "value": "0 €"
+      },
+      "target": {
+        "label": "Cible",
+        "value": "Hevy · Strava · Whoop"
+      }
     },
     "build": {
       "heading": "On construit",
@@ -58,10 +75,10 @@
     "eyebrow": "IRONTRACK · 2026 · MADE IN BELGIUM",
     "hero": {
       "kicker": "Le carnet d'atelier de ton entraînement",
-      "train": "Train",
-      "heavier": "heavier,",
-      "live": "live",
-      "lighter": "lighter.",
+      "train": "Soulève",
+      "heavier": "plus lourd,",
+      "live": "vis",
+      "lighter": "plus léger.",
       "lede": "Suis chaque rep, chaque watt, chaque calorie. Sans bullshit. Sans pub. Sans gamification creuse. Juste tes chiffres et ta progression.",
       "cta": {
         "start": "Créer mon compte gratuit",
@@ -299,6 +316,58 @@
       "title": "Lien invalide ou expiré.",
       "body": "Ce lien magique ne fonctionne plus. Demande-en un nouveau.",
       "cta": "Renvoyer un lien"
+    }
+  },
+  "legal": {
+    "eyebrow": "LÉGAL · IRONTRACK",
+    "nav": {
+      "home": "Accueil",
+      "privacy": "Vie privée",
+      "terms": "Conditions"
+    },
+    "draft": {
+      "label": "BROUILLON · v2 ALPHA",
+      "body": "Cette page est un brouillon de travail. La version finale sera publiée avant la v1.0 et sera conforme au RGPD (Belgique, UE)."
+    },
+    "privacy": {
+      "title": "Politique de confidentialité.",
+      "lede": "Tes données restent à toi. IronTrack est hébergé en Europe et pensé RGPD-first.",
+      "collect": {
+        "title": "Ce qu'on collecte",
+        "body": "Strictement l'essentiel : ton email, tes séances, tes métriques. Aucun tracking publicitaire, aucune analytique tierce. Ton avatar est stocké sur notre Supabase Storage en Europe."
+      },
+      "usage": {
+        "title": "Comment on l'utilise",
+        "body": "Pour afficher ta progression, synchroniser tes séances entre tes appareils et sécuriser ton compte. Jamais revendu. Jamais partagé avec des tiers à des fins marketing."
+      },
+      "rights": {
+        "title": "Tes droits (RGPD)",
+        "body": "Accès, rectification, effacement, export complet, portabilité. Tu nous écris et on répond sous 30 jours."
+      },
+      "contact": {
+        "title": "Contact",
+        "body": "privacy@irontrack.app — IronTrack, Belgique."
+      }
+    },
+    "terms": {
+      "title": "Conditions d'utilisation.",
+      "lede": "Les règles du jeu. Langage clair, pas de dark patterns.",
+      "service": {
+        "title": "Le service",
+        "body": "IronTrack est un suivi d'entraînement, de progression et de nutrition. Gratuit pendant l'alpha. Les formules payantes seront annoncées en toute transparence, sans reconduction automatique."
+      },
+      "account": {
+        "title": "Ton compte",
+        "body": "Tu es responsable de ton mot de passe. Signale-nous tout abus. On peut suspendre un compte en cas d'abus (bot, scraping, violation)."
+      },
+      "content": {
+        "title": "Tes contenus",
+        "body": "Tu es propriétaire de tes données. Tu peux les exporter ou les supprimer à tout moment. On ne les utilise que pour faire fonctionner le produit pour toi."
+      },
+      "liability": {
+        "title": "Responsabilité",
+        "body": "IronTrack n'est pas un avis médical. Consulte un professionnel de santé avant tout programme intensif. Le service est fourni \"en l'état\" pendant la phase alpha."
+      }
     }
   }
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -74,9 +74,19 @@
     "login": {
       "metaTitle": "Connexion · IronTrack",
       "metaDescription": "Connecte-toi à IronTrack avec un lien magique. Aucun mot de passe.",
-      "eyebrow": "ACCÈS · MAGIC LINK",
-      "title": "Connecte-toi.",
-      "lede": "Pas de mot de passe. On t'envoie un lien sécurisé par email."
+      "eyebrow": "ACCÈS · IRONTRACK",
+      "title": "Bon retour.",
+      "lede": "Connecte-toi avec Google ou reçois un lien magique par email. Pas de mot de passe à retenir.",
+      "editorialKicker": "MANIFESTE · 01",
+      "editorialQuote": "« L'iron ne ment jamais. Tes chiffres non plus. »",
+      "editorialAttribution": "Une app fitness pensée comme un carnet d'atelier. Pas de gamification creuse, pas de notifications anxiogènes. Juste tes données, tes progrès, ta routine.",
+      "terms": "En continuant, tu acceptes notre",
+      "privacy": "Politique de confidentialité",
+      "termsLink": "Conditions d'utilisation"
+    },
+    "oauth": {
+      "google": "Continuer avec Google",
+      "or": "OU PAR EMAIL"
     },
     "form": {
       "email": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -179,11 +179,11 @@
   },
   "auth": {
     "login": {
-      "metaTitle": "Connexion · IronTrack",
-      "metaDescription": "Connecte-toi à IronTrack avec un lien magique. Aucun mot de passe.",
+      "metaTitle": "Connexion",
+      "metaDescription": "Connecte-toi à IronTrack avec Google ou avec ton email et ton mot de passe.",
       "eyebrow": "ACCÈS · IRONTRACK",
       "title": "Bon retour.",
-      "lede": "Connecte-toi avec Google ou reçois un lien magique par email. Pas de mot de passe à retenir.",
+      "lede": "Connecte-toi avec Google ou avec ton email. C'est tout.",
       "editorialKicker": "MANIFESTE · 01",
       "editorialQuote": "« L'iron ne ment jamais. Tes chiffres non plus. »",
       "editorialAttribution": "Une app fitness pensée comme un carnet d'atelier. Pas de gamification creuse, pas de notifications anxiogènes. Juste tes données, tes progrès, ta routine.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -163,12 +163,60 @@
   "dashboard": {
     "eyebrow": "TABLEAU DE BORD",
     "title": "Bienvenue.",
+    "hello": "Bienvenue, {name}.",
     "greeting": "Connecté en tant que {email}.",
     "logout": "Se déconnecter",
     "back": "Retour à l'accueil",
+    "profileLink": "Mon profil",
+    "onboarding": {
+      "label": "PROFIL À COMPLÉTER",
+      "body": "Choisis un pseudo pour personnaliser ton espace et, plus tard, t'entraîner avec des partenaires.",
+      "cta": "Compléter mon profil"
+    },
     "placeholder": {
       "label": "PROCHAINE ÉTAPE",
       "body": "Le vrai tableau de bord arrive : ta dernière séance, tes records, tes prochaines sessions, tes graphes de progression."
+    }
+  },
+  "profile": {
+    "metaTitle": "Mon profil",
+    "metaDescription": "Gère ton pseudo et ton nom public IronTrack.",
+    "eyebrow": "PROFIL",
+    "title": "Toi, en chiffres.",
+    "lede": "Connecté en tant que {email}. Tu peux changer ton pseudo et ton nom à tout moment.",
+    "logout": "Se déconnecter",
+    "section": {
+      "label": "IDENTITÉ",
+      "heading": "Comment tu veux qu'on t'appelle ?"
+    },
+    "form": {
+      "pseudo": {
+        "label": "Pseudo",
+        "placeholder": "mon_pseudo",
+        "help": "3-30 caractères · minuscules, chiffres, underscore · utilisé pour te retrouver entre partenaires."
+      },
+      "fullName": {
+        "label": "Nom affiché",
+        "placeholder": "Thierry V.",
+        "help": "Jusqu'à 50 caractères · affiché sur ton tableau de bord."
+      },
+      "submit": "Enregistrer",
+      "submitPending": "Enregistrement…",
+      "saved": "Profil mis à jour."
+    },
+    "errors": {
+      "pseudoTooShort": "Pseudo trop court (3 caractères min).",
+      "pseudoTooLong": "Pseudo trop long (30 caractères max).",
+      "pseudoFormat": "Seuls minuscules, chiffres et underscore sont autorisés.",
+      "pseudoTaken": "Ce pseudo est déjà pris.",
+      "fullNameRequired": "Entre un nom ou laisse vide.",
+      "fullNameTooLong": "Nom trop long (50 caractères max).",
+      "rateLimit": "Trop de tentatives. Réessaie dans une minute.",
+      "generic": "Une erreur est survenue. Réessaie."
+    },
+    "nav": {
+      "dashboard": "Tableau de bord",
+      "home": "Accueil"
     }
   },
   "langSwitcher": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -62,7 +62,24 @@
       "lighter": "lighter.",
       "lede": "Une app fitness pensée comme un carnet d'atelier : précise, éditoriale, brutaliste. Pas de confettis. Pas de jargon. Juste ton corps, tes chiffres, ton progrès."
     },
-    "cta": { "start": "Commencer la séance", "login": "Se connecter" }
+    "cta": {
+      "start": "Commencer la séance",
+      "login": "Se connecter",
+      "dashboard": "Mon tableau de bord",
+      "logout": "Se déconnecter"
+    },
+    "greeting": "Connecté en tant que {email}"
+  },
+  "dashboard": {
+    "eyebrow": "TABLEAU DE BORD",
+    "title": "Bienvenue.",
+    "greeting": "Connecté en tant que {email}.",
+    "logout": "Se déconnecter",
+    "back": "Retour à l'accueil",
+    "placeholder": {
+      "label": "PROCHAINE ÉTAPE",
+      "body": "Le vrai tableau de bord arrive : ta dernière séance, tes records, tes prochaines sessions, tes graphes de progression."
+    }
   },
   "langSwitcher": {
     "label": "Choisir la langue",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -195,12 +195,26 @@
       "google": "Continuer avec Google",
       "or": "OU PAR EMAIL"
     },
+    "tabs": {
+      "label": "Méthode de connexion",
+      "password": "Email + mot de passe",
+      "magic": "Lien magique"
+    },
     "form": {
       "email": {
         "label": "Email",
         "placeholder": "tu@exemple.be"
       },
+      "password": {
+        "label": "Mot de passe",
+        "placeholder": "Au moins 10 caractères",
+        "help": "10 caractères min · 1 majuscule · 1 chiffre"
+      },
       "submit": "Recevoir le lien",
+      "signin": "Se connecter",
+      "signup": "Créer mon compte",
+      "toSignup": "Pas encore de compte ? Créer un compte",
+      "toSignin": "Déjà un compte ? Se connecter",
       "submitPending": "Envoi en cours…",
       "hint": "En continuant, tu acceptes nos conditions et notre politique de confidentialité (RGPD)."
     },
@@ -212,6 +226,11 @@
     "errors": {
       "emailRequired": "L'email est obligatoire.",
       "emailInvalid": "Cette adresse email n'est pas valide.",
+      "passwordTooShort": "Mot de passe trop court (10 caractères min).",
+      "passwordTooLong": "Mot de passe trop long (72 caractères max).",
+      "passwordWeak": "Ajoute au moins une majuscule, une minuscule et un chiffre.",
+      "invalidCredentials": "Email ou mot de passe incorrect.",
+      "emailTaken": "Un compte existe déjà avec cet email. Connecte-toi.",
       "rateLimit": "Trop de tentatives. Réessaie dans une minute.",
       "generic": "Une erreur est survenue. Réessaie."
     },

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -1,6 +1,11 @@
 {
-  "brand": { "name": "IronTrack", "tagline": "Train zwaarder, leef lichter." },
-  "common": { "scrollToTop": "Terug naar boven" },
+  "brand": {
+    "name": "IronTrack",
+    "tagline": "Train zwaarder, leef lichter."
+  },
+  "common": {
+    "scrollToTop": "Terug naar boven"
+  },
   "nav": {
     "home": "Start",
     "workouts": "Sessies",
@@ -21,10 +26,22 @@
     },
     "lede": "Een fitness-app gebouwd als een atelierboek: precies, redactioneel, brutalistisch. Geen confetti. Geen jargon. Enkel jouw lichaam, jouw cijfers, jouw vooruitgang.",
     "meta": {
-      "stack": { "label": "Stack", "value": "Next 16" },
-      "backend": { "label": "Backend", "value": "Supabase" },
-      "budget": { "label": "Budget", "value": "0 €" },
-      "target": { "label": "Doel", "value": "Hevy · Strava · Whoop" }
+      "stack": {
+        "label": "Stack",
+        "value": "Next 16"
+      },
+      "backend": {
+        "label": "Backend",
+        "value": "Supabase"
+      },
+      "budget": {
+        "label": "Budget",
+        "value": "0 €"
+      },
+      "target": {
+        "label": "Doel",
+        "value": "Hevy · Strava · Whoop"
+      }
     },
     "build": {
       "heading": "We bouwen",
@@ -299,6 +316,58 @@
       "title": "Ongeldige of verlopen link.",
       "body": "Deze magic link werkt niet meer. Vraag een nieuwe aan.",
       "cta": "Nieuwe link sturen"
+    }
+  },
+  "legal": {
+    "eyebrow": "JURIDISCH · IRONTRACK",
+    "nav": {
+      "home": "Home",
+      "privacy": "Privacy",
+      "terms": "Voorwaarden"
+    },
+    "draft": {
+      "label": "CONCEPT · v2 ALPHA",
+      "body": "Deze pagina is een werkversie. De definitieve versie wordt gepubliceerd vóór v1.0 en zal voldoen aan de AVG (België, EU)."
+    },
+    "privacy": {
+      "title": "Privacybeleid.",
+      "lede": "Je gegevens blijven van jou. IronTrack wordt in Europa gehost en is AVG-first ontworpen.",
+      "collect": {
+        "title": "Wat we verzamelen",
+        "body": "Strikt het essentiële: je e-mail, je sessies, je metrics. Geen advertentietracking, geen externe analytics. Je avatar staat op onze Supabase Storage in Europa."
+      },
+      "usage": {
+        "title": "Hoe we het gebruiken",
+        "body": "Om je progressie te tonen, je sessies te synchroniseren tussen je toestellen en je account te beveiligen. Nooit verkocht. Nooit gedeeld met derden voor marketing."
+      },
+      "rights": {
+        "title": "Je rechten (AVG)",
+        "body": "Inzage, rectificatie, verwijdering, volledige export, portabiliteit. Je schrijft ons en we antwoorden binnen 30 dagen."
+      },
+      "contact": {
+        "title": "Contact",
+        "body": "privacy@irontrack.app — IronTrack, België."
+      }
+    },
+    "terms": {
+      "title": "Gebruiksvoorwaarden.",
+      "lede": "De spelregels. Klare taal, geen dark patterns.",
+      "service": {
+        "title": "De dienst",
+        "body": "IronTrack is een tracker voor training, progressie en voeding. Gratis tijdens de alpha. Betaalde plannen worden transparant aangekondigd, zonder automatische verlenging."
+      },
+      "account": {
+        "title": "Je account",
+        "body": "Jij bent verantwoordelijk voor je wachtwoord. Meld misbruik aan ons. We kunnen een account opschorten bij misbruik (bot, scraping, inbreuk)."
+      },
+      "content": {
+        "title": "Jouw inhoud",
+        "body": "Jij bent eigenaar van je data. Je kan die op elk moment exporteren of verwijderen. We gebruiken ze enkel om het product voor jou te laten werken."
+      },
+      "liability": {
+        "title": "Aansprakelijkheid",
+        "body": "IronTrack is geen medisch advies. Raadpleeg een zorgverlener vóór elk intensief programma. De dienst wordt \"as is\" geleverd tijdens de alpha."
+      }
     }
   }
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -54,19 +54,108 @@
     }
   },
   "home": {
+    "eyebrow": "IRONTRACK · 2026 · MADE IN BELGIUM",
     "hero": {
-      "eyebrow": "Masterclass redesign",
+      "kicker": "Het atelierboek van je training",
       "train": "Train",
       "heavier": "zwaarder,",
       "live": "leef",
       "lighter": "lichter.",
-      "lede": "Een fitness-app gebouwd als een atelierboek: precies, redactioneel, brutalistisch. Geen confetti. Geen jargon. Enkel jouw lichaam, jouw cijfers, jouw vooruitgang."
+      "lede": "Volg elke rep, elke watt, elke calorie. Zonder onzin. Zonder reclame. Zonder lege gamification. Enkel je cijfers en je vooruitgang.",
+      "cta": {
+        "start": "Maak mijn gratis account",
+        "discover": "Ontdekken",
+        "dashboard": "Mijn dashboard"
+      }
+    },
+    "features": {
+      "eyebrow": "WAT JE KRIJGT",
+      "heading": "Alles wat nodig is.",
+      "headingAccent": "Niets overbodig.",
+      "logging": {
+        "tag": "01 · SESSIES",
+        "title": "Log elke rep, elke set.",
+        "body": "Krachttraining en cardio in één app. Sets, reps, gewicht, RPE. Voor de roeier: SPM, watts. Voor het lopen: tempo, hoogtemeters. Live-modus met rusttimer.",
+        "bullet1": "Dynamische sets",
+        "bullet2": "Geavanceerde cardio",
+        "bullet3": "Live-modus"
+      },
+      "progress": {
+        "tag": "02 · VOORUITGANG",
+        "title": "Zie waar je heen gaat.",
+        "body": "Grafieken van geschatte 1RM, weekvolume, frequentie per spiergroep. Vergelijk je cycli. Spot je plateaus voor ze zich vestigen.",
+        "bullet1": "Geschatte 1RM",
+        "bullet2": "Weekvolume",
+        "bullet3": "Persoonlijke records"
+      },
+      "nutrition": {
+        "tag": "03 · VOEDING BE",
+        "title": "Tel je macro's. In het Belgisch.",
+        "body": "Scan de barcode van je Colruyt, Delhaize of Carrefour-product. Nutri-Score, macro's, ingrediënten. Open Food Facts (3M+ producten) als basis.",
+        "bullet1": "Barcode scan",
+        "bullet2": "Nutri-Score",
+        "bullet3": "BE-producten"
+      },
+      "coach": {
+        "tag": "04 · AI COACH",
+        "title": "Een coach die luistert.",
+        "body": "Plannen aangepast aan je materiaal, je tijd, je doelen. Tips bij plateaus. Zonder schuldgevoel, zonder stresserende meldingen.",
+        "bullet1": "Aangepaste plannen",
+        "bullet2": "Anti-plateau",
+        "bullet3": "Geen druk"
+      }
+    },
+    "how": {
+      "eyebrow": "IN 3 STAPPEN",
+      "heading": "Hoe het werkt.",
+      "log": {
+        "title": "Je logt je sessie.",
+        "body": "Tijdens of erna, het maakt niet uit. Enkele taps en klaar. De app onthoudt alles: je laatste gewicht, je laatste reps, je records."
+      },
+      "track": {
+        "title": "De app onthoudt alles.",
+        "body": "Je data blijft van jou (AVG-first, hosting in Europa). Sync over toestellen. Volledige export wanneer je wilt."
+      },
+      "progress": {
+        "title": "Je ziet je vooruitgang.",
+        "body": "Geen vanity metrics. Enkel wat telt: volume, intensiteit, frequentie, slaap, voeding. Jij beslist wat te veranderen."
+      }
+    },
+    "vs": {
+      "eyebrow": "POSITIONERING",
+      "heading": "Waarom geen",
+      "headingAccent": "Hevy, Strava of Whoop ?",
+      "lede": "Elke app blinkt uit in haar baan. IronTrack maakt de brug: serieuze krachttraining, precieze cardio, Belgische voeding, zonder verplicht abonnement of reclame.",
+      "feature": "Functie",
+      "rows": {
+        "logging": "Gedetailleerde krachttraining",
+        "cardio": "Cardio (roeier, fiets, lopen)",
+        "nutrition": "Voeding + barcode scan",
+        "belgian": "Belgische producten native",
+        "noads": "Zonder reclame",
+        "opensource": "Open broncode"
+      },
+      "disclaimer": "* Vergelijking gebaseerd op publieke gratis versies in april 2026"
+    },
+    "manifesto": {
+      "eyebrow": "MANIFEST",
+      "quote": "« IJzer liegt nooit. Je cijfers ook niet. »",
+      "body": "We hebben te veel fitness-apps gezien die je training in een videogame veranderen, je schuld doen voelen als je een sessie overslaat, of je data verkopen. IronTrack doet het tegenovergestelde: een sober, precies werktuig dat je respecteert.",
+      "cta": {
+        "start": "Maak mijn gratis account",
+        "dashboard": "Mijn dashboard"
+      }
     },
     "cta": {
-      "start": "Sessie starten",
+      "start": "Maak mijn gratis account",
       "login": "Aanmelden",
       "dashboard": "Mijn dashboard",
       "logout": "Afmelden"
+    },
+    "footer": {
+      "copyright": "© IronTrack 2026 · Made in Belgium",
+      "quote": "\"The iron never lies.\"",
+      "build": "Build · v2.0.0-alpha"
     },
     "greeting": "Aangemeld als {email}"
   },
@@ -116,7 +205,8 @@
     },
     "checkEmail": {
       "title": "Check je inbox.",
-      "body": "Als het adres geldig is, ontvang je binnen enkele seconden een link. Vergeet je spam-map niet."
+      "body": "Als het adres geldig is, ontvang je binnen enkele seconden een link. Vergeet je spam-map niet.",
+      "hint": "De link opent mogelijk in een nieuw tabblad (Gmail, Outlook). Geen zorgen: dit tabblad wordt automatisch bijgewerkt zodra je bent aangemeld."
     },
     "errors": {
       "emailRequired": "E-mail is verplicht.",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -179,11 +179,11 @@
   },
   "auth": {
     "login": {
-      "metaTitle": "Aanmelden · IronTrack",
-      "metaDescription": "Meld je aan bij IronTrack met een magic link. Geen wachtwoord nodig.",
+      "metaTitle": "Aanmelden",
+      "metaDescription": "Meld je aan bij IronTrack met Google of met je e-mail en wachtwoord.",
       "eyebrow": "TOEGANG · IRONTRACK",
       "title": "Welkom terug.",
-      "lede": "Meld je aan met Google of ontvang een magic link per e-mail. Geen wachtwoord nodig.",
+      "lede": "Meld je aan met Google of met je e-mail. That's it.",
       "editorialKicker": "MANIFEST · 01",
       "editorialQuote": "« IJzer liegt nooit. Je cijfers ook niet. »",
       "editorialAttribution": "Een fitness-app als een atelierboek. Geen holle gamification, geen stresserende meldingen. Enkel je data, je vooruitgang, je routine.",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -62,7 +62,24 @@
       "lighter": "lichter.",
       "lede": "Een fitness-app gebouwd als een atelierboek: precies, redactioneel, brutalistisch. Geen confetti. Geen jargon. Enkel jouw lichaam, jouw cijfers, jouw vooruitgang."
     },
-    "cta": { "start": "Sessie starten", "login": "Aanmelden" }
+    "cta": {
+      "start": "Sessie starten",
+      "login": "Aanmelden",
+      "dashboard": "Mijn dashboard",
+      "logout": "Afmelden"
+    },
+    "greeting": "Aangemeld als {email}"
+  },
+  "dashboard": {
+    "eyebrow": "DASHBOARD",
+    "title": "Welkom.",
+    "greeting": "Aangemeld als {email}.",
+    "logout": "Afmelden",
+    "back": "Terug naar start",
+    "placeholder": {
+      "label": "VOLGENDE STAP",
+      "body": "Het echte dashboard komt eraan: je laatste sessie, je records, je volgende sessies, je voortgangsgrafieken."
+    }
   },
   "langSwitcher": {
     "label": "Taal kiezen",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -195,12 +195,26 @@
       "google": "Doorgaan met Google",
       "or": "OF MET E-MAIL"
     },
+    "tabs": {
+      "label": "Aanmeldmethode",
+      "password": "E-mail + wachtwoord",
+      "magic": "Magische link"
+    },
     "form": {
       "email": {
         "label": "E-mail",
         "placeholder": "jij@voorbeeld.be"
       },
+      "password": {
+        "label": "Wachtwoord",
+        "placeholder": "Minstens 10 tekens",
+        "help": "10 tekens min · 1 hoofdletter · 1 cijfer"
+      },
       "submit": "Stuur de link",
+      "signin": "Aanmelden",
+      "signup": "Account aanmaken",
+      "toSignup": "Nog geen account? Maak er een",
+      "toSignin": "Al een account? Aanmelden",
       "submitPending": "Versturen…",
       "hint": "Door verder te gaan, aanvaard je onze voorwaarden en ons privacybeleid (AVG)."
     },
@@ -212,6 +226,11 @@
     "errors": {
       "emailRequired": "E-mail is verplicht.",
       "emailInvalid": "Dit e-mailadres is niet geldig.",
+      "passwordTooShort": "Wachtwoord te kort (minstens 10 tekens).",
+      "passwordTooLong": "Wachtwoord te lang (max 72 tekens).",
+      "passwordWeak": "Voeg minstens één hoofdletter, één kleine letter en één cijfer toe.",
+      "invalidCredentials": "E-mail of wachtwoord onjuist.",
+      "emailTaken": "Er bestaat al een account met dit e-mailadres. Meld je aan.",
       "rateLimit": "Te veel pogingen. Probeer het over een minuut opnieuw.",
       "generic": "Er is iets misgegaan. Probeer opnieuw."
     },

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -74,9 +74,19 @@
     "login": {
       "metaTitle": "Aanmelden · IronTrack",
       "metaDescription": "Meld je aan bij IronTrack met een magic link. Geen wachtwoord nodig.",
-      "eyebrow": "TOEGANG · MAGIC LINK",
-      "title": "Meld je aan.",
-      "lede": "Geen wachtwoord. We sturen je een beveiligde link per e-mail."
+      "eyebrow": "TOEGANG · IRONTRACK",
+      "title": "Welkom terug.",
+      "lede": "Meld je aan met Google of ontvang een magic link per e-mail. Geen wachtwoord nodig.",
+      "editorialKicker": "MANIFEST · 01",
+      "editorialQuote": "« IJzer liegt nooit. Je cijfers ook niet. »",
+      "editorialAttribution": "Een fitness-app als een atelierboek. Geen holle gamification, geen stresserende meldingen. Enkel je data, je vooruitgang, je routine.",
+      "terms": "Door verder te gaan, aanvaard je ons",
+      "privacy": "Privacybeleid",
+      "termsLink": "Gebruiksvoorwaarden"
+    },
+    "oauth": {
+      "google": "Doorgaan met Google",
+      "or": "OF MET E-MAIL"
     },
     "form": {
       "email": {

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -185,6 +185,16 @@
     "title": "Jij, in cijfers.",
     "lede": "Aangemeld als {email}. Je kunt je pseudoniem en je naam op elk moment wijzigen.",
     "logout": "Afmelden",
+    "avatar": {
+      "label": "FOTO",
+      "heading": "Je profielfoto.",
+      "pick": "Foto kiezen",
+      "replace": "Foto vervangen",
+      "remove": "Verwijderen",
+      "uploading": "Uploaden…",
+      "removing": "Verwijderen…",
+      "help": "JPG, PNG, WebP of GIF · max 5 MB · vierkant aanbevolen."
+    },
     "section": {
       "label": "IDENTITEIT",
       "heading": "Hoe moeten we je noemen?"
@@ -211,6 +221,9 @@
       "pseudoTaken": "Dit pseudoniem is al in gebruik.",
       "fullNameRequired": "Vul een naam in of laat leeg.",
       "fullNameTooLong": "Naam te lang (max 50 tekens).",
+      "avatarTooLarge": "Afbeelding te groot (max 5 MB).",
+      "avatarMimeType": "Niet-ondersteund formaat. JPG, PNG, WebP of GIF.",
+      "avatarUpload": "Uploaden mislukt. Probeer opnieuw.",
       "rateLimit": "Te veel pogingen. Probeer het over een minuut opnieuw.",
       "generic": "Er is iets misgegaan. Probeer opnieuw."
     },

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -163,12 +163,60 @@
   "dashboard": {
     "eyebrow": "DASHBOARD",
     "title": "Welkom.",
+    "hello": "Welkom, {name}.",
     "greeting": "Aangemeld als {email}.",
     "logout": "Afmelden",
     "back": "Terug naar start",
+    "profileLink": "Mijn profiel",
+    "onboarding": {
+      "label": "PROFIEL AANVULLEN",
+      "body": "Kies een pseudoniem om je ruimte te personaliseren en later met trainingspartners te kunnen trainen.",
+      "cta": "Profiel aanvullen"
+    },
     "placeholder": {
       "label": "VOLGENDE STAP",
       "body": "Het echte dashboard komt eraan: je laatste sessie, je records, je volgende sessies, je voortgangsgrafieken."
+    }
+  },
+  "profile": {
+    "metaTitle": "Mijn profiel",
+    "metaDescription": "Beheer je pseudoniem en je publieke naam op IronTrack.",
+    "eyebrow": "PROFIEL",
+    "title": "Jij, in cijfers.",
+    "lede": "Aangemeld als {email}. Je kunt je pseudoniem en je naam op elk moment wijzigen.",
+    "logout": "Afmelden",
+    "section": {
+      "label": "IDENTITEIT",
+      "heading": "Hoe moeten we je noemen?"
+    },
+    "form": {
+      "pseudo": {
+        "label": "Pseudoniem",
+        "placeholder": "mijn_pseudo",
+        "help": "3-30 tekens · kleine letters, cijfers, underscore · om je tussen partners te vinden."
+      },
+      "fullName": {
+        "label": "Weergavenaam",
+        "placeholder": "Thierry V.",
+        "help": "Tot 50 tekens · getoond op je dashboard."
+      },
+      "submit": "Opslaan",
+      "submitPending": "Opslaan…",
+      "saved": "Profiel bijgewerkt."
+    },
+    "errors": {
+      "pseudoTooShort": "Pseudoniem te kort (minstens 3 tekens).",
+      "pseudoTooLong": "Pseudoniem te lang (max 30 tekens).",
+      "pseudoFormat": "Alleen kleine letters, cijfers en underscore zijn toegestaan.",
+      "pseudoTaken": "Dit pseudoniem is al in gebruik.",
+      "fullNameRequired": "Vul een naam in of laat leeg.",
+      "fullNameTooLong": "Naam te lang (max 50 tekens).",
+      "rateLimit": "Te veel pogingen. Probeer het over een minuut opnieuw.",
+      "generic": "Er is iets misgegaan. Probeer opnieuw."
+    },
+    "nav": {
+      "dashboard": "Dashboard",
+      "home": "Start"
     }
   },
   "langSwitcher": {

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -1,5 +1,6 @@
 {
   "brand": { "name": "IronTrack", "tagline": "Train zwaarder, leef lichter." },
+  "common": { "scrollToTop": "Terug naar boven" },
   "nav": {
     "home": "Start",
     "workouts": "Sessies",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -208,7 +208,7 @@
       "password": {
         "label": "Wachtwoord",
         "placeholder": "Minstens 10 tekens",
-        "help": "10 tekens min · 1 hoofdletter · 1 cijfer"
+        "help": "10 tekens · 1 hoofdletter · 1 cijfer · 1 speciaal teken (!@#…)"
       },
       "submit": "Stuur de link",
       "signin": "Aanmelden",
@@ -228,7 +228,7 @@
       "emailInvalid": "Dit e-mailadres is niet geldig.",
       "passwordTooShort": "Wachtwoord te kort (minstens 10 tekens).",
       "passwordTooLong": "Wachtwoord te lang (max 72 tekens).",
-      "passwordWeak": "Voeg minstens één hoofdletter, één kleine letter en één cijfer toe.",
+      "passwordWeak": "Voeg minstens één hoofdletter, één kleine letter, één cijfer en één speciaal teken toe (!@#$…).",
       "invalidCredentials": "E-mail of wachtwoord onjuist.",
       "emailTaken": "Er bestaat al een account met dit e-mailadres. Meld je aan.",
       "rateLimit": "Te veel pogingen. Probeer het over een minuut opnieuw.",

--- a/src/lib/auth/schema.ts
+++ b/src/lib/auth/schema.ts
@@ -25,7 +25,10 @@ export const passwordSchema = z
   .max(72, { message: 'auth.errors.passwordTooLong' })
   .regex(/[a-z]/, { message: 'auth.errors.passwordWeak' })
   .regex(/[A-Z]/, { message: 'auth.errors.passwordWeak' })
-  .regex(/[0-9]/, { message: 'auth.errors.passwordWeak' });
+  .regex(/[0-9]/, { message: 'auth.errors.passwordWeak' })
+  .regex(/[!@#$%^&*()_+\-=[\]{};':"|<>?,./`~\\]/, {
+    message: 'auth.errors.passwordWeak',
+  });
 
 export const credentialsSchema = z.object({
   email: magicLinkSchema.shape.email,

--- a/src/lib/auth/schema.ts
+++ b/src/lib/auth/schema.ts
@@ -14,3 +14,22 @@ export const magicLinkSchema = z.object({
 });
 
 export type MagicLinkInput = z.infer<typeof magicLinkSchema>;
+
+/**
+ * Schéma password : 10 chars min, au moins 1 minuscule + 1 majuscule + 1 chiffre.
+ * Aligné sur la config Supabase (password_min_length=10).
+ */
+export const passwordSchema = z
+  .string()
+  .min(10, { message: 'auth.errors.passwordTooShort' })
+  .max(72, { message: 'auth.errors.passwordTooLong' })
+  .regex(/[a-z]/, { message: 'auth.errors.passwordWeak' })
+  .regex(/[A-Z]/, { message: 'auth.errors.passwordWeak' })
+  .regex(/[0-9]/, { message: 'auth.errors.passwordWeak' });
+
+export const credentialsSchema = z.object({
+  email: magicLinkSchema.shape.email,
+  password: passwordSchema,
+});
+
+export type CredentialsInput = z.infer<typeof credentialsSchema>;

--- a/src/lib/profile/avatar.ts
+++ b/src/lib/profile/avatar.ts
@@ -1,0 +1,68 @@
+/**
+ * Constantes + helpers avatar (partagés client + serveur).
+ *
+ * Le bucket Supabase `avatars` est public et accepte image/jpeg, image/png,
+ * image/webp, image/gif avec une limite de 5 MB (configuré côté Supabase).
+ * Les policies RLS imposent que le chemin commence par `${auth.uid()}/`.
+ */
+
+export const AVATAR_BUCKET = 'avatars';
+
+export const AVATAR_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export const AVATAR_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+] as const;
+
+export type AvatarMimeType = (typeof AVATAR_MIME_TYPES)[number];
+
+const EXT_BY_MIME: Record<AvatarMimeType, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+};
+
+export function isAvatarMimeType(mime: string): mime is AvatarMimeType {
+  return (AVATAR_MIME_TYPES as readonly string[]).includes(mime);
+}
+
+export function avatarExtFor(mime: AvatarMimeType): string {
+  return EXT_BY_MIME[mime];
+}
+
+/**
+ * Construit un chemin safe pour un nouvel avatar.
+ * Format : `${userId}/${uuid}.${ext}` — RLS storage le requiert.
+ */
+export function buildAvatarPath(userId: string, mime: AvatarMimeType): string {
+  const uuid = crypto.randomUUID();
+  return `${userId}/${uuid}.${avatarExtFor(mime)}`;
+}
+
+/**
+ * Extrait le path Storage (`userId/uuid.ext`) depuis une URL publique Supabase.
+ * Retourne `null` si ce n'est pas une URL du bucket `avatars`.
+ */
+export function pathFromPublicUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const marker = `/storage/v1/object/public/${AVATAR_BUCKET}/`;
+  const idx = url.indexOf(marker);
+  if (idx < 0) return null;
+  return url.slice(idx + marker.length).split('?')[0] ?? null;
+}
+
+/**
+ * Initiales (1 ou 2 lettres max) à afficher dans l'Avatar quand pas d'image.
+ */
+export function initialsFor(displayName: string): string {
+  const s = displayName.trim();
+  if (!s) return '?';
+  const parts = s.split(/[\s_.-]+/).filter(Boolean);
+  if (parts.length === 0) return s.slice(0, 1).toUpperCase();
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
+}

--- a/src/lib/profile/index.ts
+++ b/src/lib/profile/index.ts
@@ -1,0 +1,77 @@
+import type { User } from '@supabase/supabase-js';
+
+import { createServerClient, type Tables } from '@/lib/supabase';
+
+/**
+ * Profile v2.
+ *
+ * La table `profiles` legacy v1 contient déjà ~25 colonnes. Pour le v2 on
+ * n'utilise que ce sous-ensemble (pseudo, full_name, avatar_url, locale,
+ * email). Les autres colonnes sont héritées mais non éditées ici.
+ *
+ * `locale` a été ajouté par la migration 20260417120457 : le type généré peut
+ * être périmé → on étend explicitement.
+ */
+export type Profile = Tables<'profiles'> & {
+  locale?: string | null;
+};
+
+/**
+ * Récupère le profil courant (ligne `profiles` de l'utilisateur connecté).
+ * Renvoie `null` si l'utilisateur n'est pas connecté ou si le profil n'existe
+ * pas encore (le trigger `handle_new_user` le crée normalement au signup).
+ */
+export async function getProfile(): Promise<Profile | null> {
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (error) {
+    // Ne pas casser la page si la lecture échoue (ex: RLS mal configuré en dev).
+    // Les pages appelantes retombent sur l'email de l'utilisateur.
+    console.error('[getProfile] Supabase error:', error.message);
+    return null;
+  }
+  return (data ?? null) as Profile | null;
+}
+
+/**
+ * Nom à afficher dans l'UI. Priorité :
+ *   1. pseudo (handle @xxx)
+ *   2. full_name (nom complet)
+ *   3. partie locale de l'email (avant @)
+ *   4. "you" (fallback ultime)
+ */
+export function getDisplayName(
+  profile: Profile | null,
+  user: Pick<User, 'email'> | null,
+): string {
+  const pseudo = profile?.pseudo?.trim();
+  if (pseudo) return pseudo;
+
+  const fullName = profile?.full_name?.trim();
+  if (fullName) return fullName;
+
+  const email = user?.email ?? profile?.email ?? null;
+  if (email && email.includes('@')) {
+    return email.split('@')[0] ?? email;
+  }
+  return email ?? 'you';
+}
+
+/**
+ * Indique si le profil a besoin d'un onboarding v2 (aucun pseudo ni nom
+ * complet défini). Utilisé par le dashboard pour afficher un prompt inline.
+ */
+export function needsProfileOnboarding(profile: Profile | null): boolean {
+  if (!profile) return true;
+  return !profile.pseudo && !profile.full_name;
+}

--- a/src/lib/profile/schema.ts
+++ b/src/lib/profile/schema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+/**
+ * Schéma pseudo : 3-30 caractères, minuscules + chiffres + underscore.
+ * Aligné sur la contrainte SQL `profiles_pseudo_format`.
+ */
+const rawPseudo = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .min(3, { message: 'profile.errors.pseudoTooShort' })
+  .max(30, { message: 'profile.errors.pseudoTooLong' })
+  .regex(/^[a-z0-9_]+$/, { message: 'profile.errors.pseudoFormat' });
+
+const rawFullName = z
+  .string()
+  .trim()
+  .min(1, { message: 'profile.errors.fullNameRequired' })
+  .max(50, { message: 'profile.errors.fullNameTooLong' });
+
+/**
+ * Champs optionnels : string vide => null.
+ * Si non vide, validation stricte.
+ */
+export const profileFormSchema = z.object({
+  pseudo: z
+    .union([z.literal(''), rawPseudo])
+    .transform((v) => (v === '' ? null : v)),
+  full_name: z
+    .union([z.literal(''), rawFullName])
+    .transform((v) => (v === '' ? null : v)),
+});
+
+export type ProfileFormInput = z.infer<typeof profileFormSchema>;


### PR DESCRIPTION
## Scope (stack consolidée via rebase)

Cette PR regroupe l'intégralité de la refonte v2 jusqu'au merge de PR #43 (avatar + mobile + a11y) :

- **Auth** : Google OAuth + email/password + middleware i18n + Supabase SSR (ex-PR #38, #39, #40)
- **Home éditorial** : scroll-to-top, cross-tab sync, design brutaliste (ex-PR #41)
- **Profile v2** : pseudo + display_name + onboarding inline dashboard (ex-PR #42)
- **Avatar** : Supabase Storage, uploader, affichage cross-app (ex-PR #43)
- **Mobile 2026** : headers responsives, touch targets ≥ 44px, overflow corrigés
- **A11y** : avatar decorative dans les liens, duplication SR évitée
- **Legal stubs** : /legal/privacy + /legal/terms (FR/NL/EN, RGPD-first)
- **FR hero traduit** : "Soulève plus lourd, vis plus léger."

PRs #39-41 fermées comme superseded (même code intégré dans ce rebase).

## Test plan

- [x] Mobile 390px : dashboard + profile + home (no overflow)
- [x] Avatar : upload 64x64 orange PNG + Supprimer (initiales fallback)
- [x] Cross-app : pseudo + avatar propagés dashboard/hero
- [x] Legal pages : /fr/legal/privacy + /legal/terms rendent
- [x] FR hero : "Soulève plus lourd, vis plus léger."
- [x] Sourcery nested-forms bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)