### PR TITLE
feat(profile): upload avatar + affichage cross-app

### DIFF
--- a/src/app/[locale]/_home/hero.tsx
+++ b/src/app/[locale]/_home/hero.tsx
@@ -65,13 +65,14 @@ export function HomeHero({
               {displayName && (
                 <Link
                   href={`/${locale}/profile`}
-                  className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+                  className="inline-flex min-h-11 items-center gap-2 py-2 font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
                   style={{ color: 'var(--color-muted-foreground)' }}
                 >
                   <Avatar
                     src={avatarUrl}
                     displayName={displayName}
                     size="sm"
+                    decorative
                   />
                   {displayName}
                 </Link>

--- a/src/app/[locale]/_home/hero.tsx
+++ b/src/app/[locale]/_home/hero.tsx
@@ -1,15 +1,22 @@
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 
+import { Avatar } from '@/components/avatar';
 import type { Locale } from '@/i18n/request';
 
 interface HeroProps {
   locale: Locale;
   isAuthenticated: boolean;
   displayName?: string | null;
+  avatarUrl?: string | null;
 }
 
-export function HomeHero({ locale, isAuthenticated, displayName }: HeroProps) {
+export function HomeHero({
+  locale,
+  isAuthenticated,
+  displayName,
+  avatarUrl,
+}: HeroProps) {
   const t = useTranslations('home.hero');
 
   return (
@@ -56,12 +63,18 @@ export function HomeHero({ locale, isAuthenticated, displayName }: HeroProps) {
                 </span>
               </Link>
               {displayName && (
-                <span
-                  className="font-mono text-xs uppercase tracking-widest"
+                <Link
+                  href={`/${locale}/profile`}
+                  className="inline-flex items-center gap-2 font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
                   style={{ color: 'var(--color-muted-foreground)' }}
                 >
-                  · {displayName}
-                </span>
+                  <Avatar
+                    src={avatarUrl}
+                    displayName={displayName}
+                    size="sm"
+                  />
+                  {displayName}
+                </Link>
               )}
             </>
           ) : (

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -34,7 +34,7 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
 
   return (
     <main className="mx-auto max-w-4xl px-6 py-16">
-      <header className="mb-12 flex items-start justify-between gap-4">
+      <header className="mb-12 flex flex-col items-start gap-6 sm:flex-row sm:justify-between sm:gap-4">
         <div className="flex items-start gap-5">
           <Link
             href={`/${typedLocale}/profile`}
@@ -47,19 +47,19 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
               size="lg"
             />
           </Link>
-          <div>
+          <div className="min-w-0">
             <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
               {t('eyebrow')}
             </p>
-            <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
+            <h1 className="mt-3 font-display text-4xl leading-tight text-foreground break-words sm:text-5xl">
               {t('hello', { name: displayName })}
             </h1>
-            <p className="mt-3 text-base text-muted-foreground">
+            <p className="mt-3 break-words text-base text-muted-foreground">
               {t('greeting', { email: user.email ?? '' })}
             </p>
           </div>
         </div>
-        <form action={signOut}>
+        <form action={signOut} className="shrink-0">
           <input type="hidden" name="locale" value={typedLocale} />
           <button
             type="submit"
@@ -105,13 +105,13 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
         <div className="mt-6 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
           <Link
             href={`/${typedLocale}/profile`}
-            className="underline-offset-4 hover:underline"
+            className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
           >
             {t('profileLink')} →
           </Link>
           <Link
             href={`/${typedLocale}`}
-            className="underline-offset-4 hover:underline"
+            className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
           >
             ← {t('back')}
           </Link>

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
+import { Avatar } from '@/components/avatar';
 import { LOCALES, type Locale } from '@/i18n/request';
 import { requireUser } from '@/lib/auth';
 import { getDisplayName, getProfile, needsProfileOnboarding } from '@/lib/profile';
@@ -34,16 +35,29 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
   return (
     <main className="mx-auto max-w-4xl px-6 py-16">
       <header className="mb-12 flex items-start justify-between gap-4">
-        <div>
-          <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
-            {t('eyebrow')}
-          </p>
-          <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
-            {t('hello', { name: displayName })}
-          </h1>
-          <p className="mt-3 text-base text-muted-foreground">
-            {t('greeting', { email: user.email ?? '' })}
-          </p>
+        <div className="flex items-start gap-5">
+          <Link
+            href={`/${typedLocale}/profile`}
+            aria-label={t('profileLink')}
+            className="mt-1 shrink-0"
+          >
+            <Avatar
+              src={profile?.avatar_url ?? null}
+              displayName={displayName}
+              size="lg"
+            />
+          </Link>
+          <div>
+            <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+              {t('eyebrow')}
+            </p>
+            <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
+              {t('hello', { name: displayName })}
+            </h1>
+            <p className="mt-3 text-base text-muted-foreground">
+              {t('greeting', { email: user.email ?? '' })}
+            </p>
+          </div>
         </div>
         <form action={signOut}>
           <input type="hidden" name="locale" value={typedLocale} />

--- a/src/app/[locale]/legal/layout.tsx
+++ b/src/app/[locale]/legal/layout.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+
+interface LegalLayoutProps {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}
+
+export default async function LegalLayout({
+  children,
+  params,
+}: LegalLayoutProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-16">
+      <nav className="mb-12 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
+        <Link
+          href={`/${typedLocale}`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          ← {t('nav.home')}
+        </Link>
+        <Link
+          href={`/${typedLocale}/legal/privacy`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          {t('nav.privacy')}
+        </Link>
+        <Link
+          href={`/${typedLocale}/legal/terms`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          {t('nav.terms')}
+        </Link>
+      </nav>
+      {children}
+    </main>
+  );
+}

--- a/src/app/[locale]/legal/privacy/page.tsx
+++ b/src/app/[locale]/legal/privacy/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+  return {
+    title: t('privacy.title'),
+    description: t('privacy.lede'),
+  };
+}
+
+export default async function PrivacyPage({ params }: PageProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+
+  return (
+    <article className="space-y-8">
+      <header>
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          {t('eyebrow')}
+        </p>
+        <h1 className="mt-3 font-display text-4xl leading-tight text-foreground break-words sm:text-5xl">
+          {t('privacy.title')}
+        </h1>
+        <p className="mt-4 text-base text-muted-foreground">
+          {t('privacy.lede')}
+        </p>
+      </header>
+
+      <section
+        className="border-2 p-6"
+        style={{
+          borderColor: 'var(--color-brand, var(--color-foreground))',
+          background: 'color-mix(in oklab, var(--color-brand) 8%, transparent)',
+        }}
+      >
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('draft.label')}
+        </p>
+        <p className="mt-2 font-display text-xl leading-snug text-foreground">
+          {t('draft.body')}
+        </p>
+      </section>
+
+      <section className="space-y-4 text-base text-foreground">
+        <h2 className="font-display text-2xl">{t('privacy.collect.title')}</h2>
+        <p>{t('privacy.collect.body')}</p>
+        <h2 className="font-display text-2xl">{t('privacy.usage.title')}</h2>
+        <p>{t('privacy.usage.body')}</p>
+        <h2 className="font-display text-2xl">{t('privacy.rights.title')}</h2>
+        <p>{t('privacy.rights.body')}</p>
+        <h2 className="font-display text-2xl">{t('privacy.contact.title')}</h2>
+        <p>{t('privacy.contact.body')}</p>
+      </section>
+    </article>
+  );
+}

--- a/src/app/[locale]/legal/terms/page.tsx
+++ b/src/app/[locale]/legal/terms/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+  return {
+    title: t('terms.title'),
+    description: t('terms.lede'),
+  };
+}
+
+export default async function TermsPage({ params }: PageProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+  const t = await getTranslations({ locale: typedLocale, namespace: 'legal' });
+
+  return (
+    <article className="space-y-8">
+      <header>
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          {t('eyebrow')}
+        </p>
+        <h1 className="mt-3 font-display text-4xl leading-tight text-foreground break-words sm:text-5xl">
+          {t('terms.title')}
+        </h1>
+        <p className="mt-4 text-base text-muted-foreground">
+          {t('terms.lede')}
+        </p>
+      </header>
+
+      <section
+        className="border-2 p-6"
+        style={{
+          borderColor: 'var(--color-brand, var(--color-foreground))',
+          background: 'color-mix(in oklab, var(--color-brand) 8%, transparent)',
+        }}
+      >
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('draft.label')}
+        </p>
+        <p className="mt-2 font-display text-xl leading-snug text-foreground">
+          {t('draft.body')}
+        </p>
+      </section>
+
+      <section className="space-y-4 text-base text-foreground">
+        <h2 className="font-display text-2xl">{t('terms.service.title')}</h2>
+        <p>{t('terms.service.body')}</p>
+        <h2 className="font-display text-2xl">{t('terms.account.title')}</h2>
+        <p>{t('terms.account.body')}</p>
+        <h2 className="font-display text-2xl">{t('terms.content.title')}</h2>
+        <p>{t('terms.content.body')}</p>
+        <h2 className="font-display text-2xl">{t('terms.liability.title')}</h2>
+        <p>{t('terms.liability.body')}</p>
+      </section>
+    </article>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -63,6 +63,7 @@ export default async function HomePage({ params }: HomePageProps) {
             locale={typedLocale}
             isAuthenticated={Boolean(user)}
             displayName={displayName}
+            avatarUrl={profile?.avatar_url ?? null}
           />
         </div>
 

--- a/src/app/[locale]/profile/actions.ts
+++ b/src/app/[locale]/profile/actions.ts
@@ -5,6 +5,13 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { DEFAULT_LOCALE, LOCALES, type Locale } from '@/i18n/request';
+import {
+  AVATAR_BUCKET,
+  AVATAR_MAX_BYTES,
+  buildAvatarPath,
+  isAvatarMimeType,
+  pathFromPublicUrl,
+} from '@/lib/profile/avatar';
 import { getClientIp, rateLimit } from '@/lib/rate-limit';
 import { profileFormSchema } from '@/lib/profile/schema';
 import { createServerClient } from '@/lib/supabase';
@@ -16,13 +23,23 @@ export type ProfileErrorKey =
   | 'profile.errors.pseudoTaken'
   | 'profile.errors.fullNameRequired'
   | 'profile.errors.fullNameTooLong'
+  | 'profile.errors.avatarTooLarge'
+  | 'profile.errors.avatarMimeType'
+  | 'profile.errors.avatarUpload'
   | 'profile.errors.rateLimit'
   | 'profile.errors.generic';
 
 export interface ProfileState {
   status: 'idle' | 'success' | 'error';
   error?: ProfileErrorKey;
-  field?: 'pseudo' | 'full_name' | 'form';
+  field?: 'pseudo' | 'full_name' | 'avatar' | 'form';
+}
+
+export interface AvatarState {
+  status: 'idle' | 'success' | 'error';
+  error?: ProfileErrorKey;
+  /** URL publique fraîche (avec cache-buster) après un upload réussi. */
+  avatarUrl?: string | null;
 }
 
 function isLocale(l: string): l is Locale {
@@ -87,4 +104,157 @@ export async function updateProfile(
   revalidatePath(`/${locale}`);
 
   return { status: 'success' };
+}
+
+/**
+ * Upload d'un avatar dans le bucket Storage `avatars`.
+ *
+ * Sécurité :
+ *   - Auth obligatoire
+ *   - Rate-limit 5 / 60s par IP (contre abus storage)
+ *   - Validation taille (5 MB) + mime (jpeg/png/webp/gif)
+ *   - Path forcé `${userId}/uuid.ext` (RLS bucket le requiert)
+ *   - L'ancien fichier (s'il existait) est supprimé après succès
+ *
+ * Retour : nouvelle URL publique avec cache-buster `?v=Date.now()`.
+ */
+export async function uploadAvatar(
+  _prev: AvatarState,
+  formData: FormData,
+): Promise<AvatarState> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`avatar:${ip}`, { limit: 5, windowMs: 60_000 });
+  if (!ok) {
+    return { status: 'error', error: 'profile.errors.rateLimit' };
+  }
+
+  const rawLocale = String(formData.get('locale') ?? '');
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+
+  const file = formData.get('avatar');
+  if (!(file instanceof File) || file.size === 0) {
+    return { status: 'error', error: 'profile.errors.generic' };
+  }
+
+  if (file.size > AVATAR_MAX_BYTES) {
+    return { status: 'error', error: 'profile.errors.avatarTooLarge' };
+  }
+  if (!isAvatarMimeType(file.type)) {
+    return { status: 'error', error: 'profile.errors.avatarMimeType' };
+  }
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/${locale}/login`);
+  }
+
+  // Ancienne URL (pour cleanup après succès)
+  const { data: current } = await supabase
+    .from('profiles')
+    .select('avatar_url')
+    .eq('id', user.id)
+    .maybeSingle();
+  const previousPath = pathFromPublicUrl(current?.avatar_url);
+
+  const path = buildAvatarPath(user.id, file.type);
+  const { error: uploadErr } = await supabase.storage
+    .from(AVATAR_BUCKET)
+    .upload(path, file, {
+      cacheControl: '3600',
+      contentType: file.type,
+      upsert: false,
+    });
+
+  if (uploadErr) {
+    console.error('[uploadAvatar] storage error:', uploadErr.message);
+    return { status: 'error', error: 'profile.errors.avatarUpload' };
+  }
+
+  const { data: pub } = supabase.storage.from(AVATAR_BUCKET).getPublicUrl(path);
+  const publicUrl = pub.publicUrl;
+
+  const { error: updateErr } = await supabase
+    .from('profiles')
+    .update({ avatar_url: publicUrl })
+    .eq('id', user.id);
+
+  if (updateErr) {
+    // Cleanup : on tente de retirer le fichier qu'on vient d'uploader pour
+    // éviter un orphelin.
+    await supabase.storage.from(AVATAR_BUCKET).remove([path]);
+    return { status: 'error', error: 'profile.errors.generic' };
+  }
+
+  // Cleanup ancien avatar (best-effort, on ignore les erreurs)
+  if (previousPath && previousPath !== path) {
+    await supabase.storage.from(AVATAR_BUCKET).remove([previousPath]);
+  }
+
+  revalidatePath(`/${locale}/profile`);
+  revalidatePath(`/${locale}/dashboard`);
+  revalidatePath(`/${locale}`);
+
+  return {
+    status: 'success',
+    avatarUrl: `${publicUrl}?v=${Date.now()}`,
+  };
+}
+
+/**
+ * Supprime l'avatar : clear `profiles.avatar_url` + delete du fichier storage.
+ */
+export async function removeAvatar(
+  _prev: AvatarState,
+  formData: FormData,
+): Promise<AvatarState> {
+  const headerList = await headers();
+  const ip = getClientIp(headerList);
+
+  const { ok } = rateLimit(`avatar:${ip}`, { limit: 5, windowMs: 60_000 });
+  if (!ok) {
+    return { status: 'error', error: 'profile.errors.rateLimit' };
+  }
+
+  const rawLocale = String(formData.get('locale') ?? '');
+  const locale: Locale = isLocale(rawLocale) ? rawLocale : DEFAULT_LOCALE;
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect(`/${locale}/login`);
+  }
+
+  const { data: current } = await supabase
+    .from('profiles')
+    .select('avatar_url')
+    .eq('id', user.id)
+    .maybeSingle();
+  const path = pathFromPublicUrl(current?.avatar_url);
+
+  const { error: updateErr } = await supabase
+    .from('profiles')
+    .update({ avatar_url: null })
+    .eq('id', user.id);
+
+  if (updateErr) {
+    return { status: 'error', error: 'profile.errors.generic' };
+  }
+
+  // Cleanup best-effort
+  if (path) {
+    await supabase.storage.from(AVATAR_BUCKET).remove([path]);
+  }
+
+  revalidatePath(`/${locale}/profile`);
+  revalidatePath(`/${locale}/dashboard`);
+  revalidatePath(`/${locale}`);
+
+  return { status: 'success', avatarUrl: null };
 }

--- a/src/app/[locale]/profile/avatar-uploader.tsx
+++ b/src/app/[locale]/profile/avatar-uploader.tsx
@@ -69,10 +69,18 @@ export function AvatarUploader({
       <Avatar src={previewUrl} displayName={displayName} size="xl" />
 
       <div className="flex flex-col gap-3">
+        {/*
+          Deux <form> frères (non imbriqués) — le bouton "Choisir/Remplacer"
+          appartient au form d'upload via l'attribut `form`, le bouton
+          "Supprimer" appartient au form de suppression. HTML valide, pas
+          de soumission croisée possible. Le file input déclenche
+          `requestSubmit()` sur le form d'upload après validation client.
+        */}
         <form
           ref={formRef}
+          id="avatar-upload-form"
           action={uploadAction}
-          className="flex flex-col gap-2"
+          className="contents"
         >
           <input type="hidden" name="locale" value={locale} />
           <input
@@ -101,37 +109,43 @@ export function AvatarUploader({
               formRef.current?.requestSubmit();
             }}
           />
-
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              type="button"
-              variant="outline"
-              disabled={uploadPending || removePending}
-              onClick={() => fileRef.current?.click()}
-              className="min-h-[44px] border-2 border-foreground px-5 font-mono text-xs uppercase tracking-widest"
-            >
-              {uploadPending
-                ? t('avatar.uploading')
-                : previewUrl
-                  ? t('avatar.replace')
-                  : t('avatar.pick')}
-            </Button>
-
-            {previewUrl && (
-              <form action={removeAction}>
-                <input type="hidden" name="locale" value={locale} />
-                <Button
-                  type="submit"
-                  variant="ghost"
-                  disabled={uploadPending || removePending}
-                  className="min-h-[44px] px-3 font-mono text-xs uppercase tracking-widest"
-                >
-                  {removePending ? t('avatar.removing') : t('avatar.remove')}
-                </Button>
-              </form>
-            )}
-          </div>
         </form>
+
+        <form
+          id="avatar-remove-form"
+          action={removeAction}
+          className="contents"
+        >
+          <input type="hidden" name="locale" value={locale} />
+        </form>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={uploadPending || removePending}
+            onClick={() => fileRef.current?.click()}
+            className="min-h-[44px] border-2 border-foreground px-5 font-mono text-xs uppercase tracking-widest"
+          >
+            {uploadPending
+              ? t('avatar.uploading')
+              : previewUrl
+                ? t('avatar.replace')
+                : t('avatar.pick')}
+          </Button>
+
+          {previewUrl && (
+            <Button
+              type="submit"
+              form="avatar-remove-form"
+              variant="ghost"
+              disabled={uploadPending || removePending}
+              className="min-h-[44px] px-3 font-mono text-xs uppercase tracking-widest"
+            >
+              {removePending ? t('avatar.removing') : t('avatar.remove')}
+            </Button>
+          )}
+        </div>
 
         <p className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
           {t('avatar.help')}

--- a/src/app/[locale]/profile/avatar-uploader.tsx
+++ b/src/app/[locale]/profile/avatar-uploader.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useActionState, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { Avatar } from '@/components/avatar';
+import { Button } from '@/components/ui/button';
+import {
+  AVATAR_MAX_BYTES,
+  AVATAR_MIME_TYPES,
+  isAvatarMimeType,
+} from '@/lib/profile/avatar';
+
+import {
+  removeAvatar,
+  uploadAvatar,
+  type AvatarState,
+} from './actions';
+
+const initial: AvatarState = { status: 'idle' };
+
+interface AvatarUploaderProps {
+  locale: string;
+  displayName: string;
+  initialAvatarUrl: string | null;
+}
+
+export function AvatarUploader({
+  locale,
+  displayName,
+  initialAvatarUrl,
+}: AvatarUploaderProps) {
+  const t = useTranslations('profile');
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const [clientError, setClientError] = useState<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(initialAvatarUrl);
+
+  const [uploadState, uploadAction, uploadPending] = useActionState(
+    uploadAvatar,
+    initial,
+  );
+  const [removeState, removeAction, removePending] = useActionState(
+    removeAvatar,
+    initial,
+  );
+
+  // Sync preview après succès server
+  useEffect(() => {
+    if (uploadState.status === 'success') {
+      setPreviewUrl(uploadState.avatarUrl ?? null);
+      setClientError(null);
+    }
+  }, [uploadState]);
+  useEffect(() => {
+    if (removeState.status === 'success') {
+      setPreviewUrl(null);
+      setClientError(null);
+    }
+  }, [removeState]);
+
+  const serverError =
+    uploadState.status === 'error' ? uploadState.error :
+    removeState.status === 'error' ? removeState.error :
+    null;
+
+  return (
+    <div className="flex flex-col gap-5 sm:flex-row sm:items-center sm:gap-8">
+      <Avatar src={previewUrl} displayName={displayName} size="xl" />
+
+      <div className="flex flex-col gap-3">
+        <form
+          ref={formRef}
+          action={uploadAction}
+          className="flex flex-col gap-2"
+        >
+          <input type="hidden" name="locale" value={locale} />
+          <input
+            ref={fileRef}
+            type="file"
+            name="avatar"
+            accept={AVATAR_MIME_TYPES.join(',')}
+            className="sr-only"
+            aria-label={t('avatar.pick')}
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (!f) return;
+
+              // Validation client (évite un aller-retour serveur)
+              if (f.size > AVATAR_MAX_BYTES) {
+                setClientError(t('errors.avatarTooLarge'));
+                e.target.value = '';
+                return;
+              }
+              if (!isAvatarMimeType(f.type)) {
+                setClientError(t('errors.avatarMimeType'));
+                e.target.value = '';
+                return;
+              }
+              setClientError(null);
+              formRef.current?.requestSubmit();
+            }}
+          />
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={uploadPending || removePending}
+              onClick={() => fileRef.current?.click()}
+              className="min-h-[44px] border-2 border-foreground px-5 font-mono text-xs uppercase tracking-widest"
+            >
+              {uploadPending
+                ? t('avatar.uploading')
+                : previewUrl
+                  ? t('avatar.replace')
+                  : t('avatar.pick')}
+            </Button>
+
+            {previewUrl && (
+              <form action={removeAction}>
+                <input type="hidden" name="locale" value={locale} />
+                <Button
+                  type="submit"
+                  variant="ghost"
+                  disabled={uploadPending || removePending}
+                  className="min-h-[44px] px-3 font-mono text-xs uppercase tracking-widest"
+                >
+                  {removePending ? t('avatar.removing') : t('avatar.remove')}
+                </Button>
+              </form>
+            )}
+          </div>
+        </form>
+
+        <p className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+          {t('avatar.help')}
+        </p>
+
+        {clientError && (
+          <p role="alert" className="text-sm font-medium text-destructive">
+            {clientError}
+          </p>
+        )}
+        {!clientError && serverError && (
+          <p role="alert" className="text-sm font-medium text-destructive">
+            {t(serverError.replace('profile.', '') as 'errors.generic')}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -43,19 +43,19 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
 
   return (
     <main className="mx-auto max-w-3xl px-6 py-16">
-      <header className="mb-12 flex items-start justify-between gap-4">
-        <div>
+      <header className="mb-12 flex flex-col items-start gap-6 sm:flex-row sm:justify-between sm:gap-4">
+        <div className="min-w-0">
           <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
             {t('eyebrow')}
           </p>
-          <h1 className="mt-3 font-display text-5xl leading-tight text-foreground">
+          <h1 className="mt-3 font-display text-4xl leading-tight text-foreground break-words sm:text-5xl">
             {t('title')}
           </h1>
-          <p className="mt-3 text-base text-muted-foreground">
+          <p className="mt-3 break-words text-base text-muted-foreground">
             {t('lede', { email: user.email ?? '' })}
           </p>
         </div>
-        <form action={signOut}>
+        <form action={signOut} className="shrink-0">
           <input type="hidden" name="locale" value={typedLocale} />
           <button
             type="submit"
@@ -99,13 +99,13 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
       <nav className="mt-10 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
         <Link
           href={`/${typedLocale}/dashboard`}
-          className="underline-offset-4 hover:underline"
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
         >
           ← {t('nav.dashboard')}
         </Link>
         <Link
           href={`/${typedLocale}`}
-          className="underline-offset-4 hover:underline"
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
         >
           {t('nav.home')}
         </Link>

--- a/src/app/[locale]/profile/page.tsx
+++ b/src/app/[locale]/profile/page.tsx
@@ -4,9 +4,10 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import { LOCALES, type Locale } from '@/i18n/request';
 import { requireUser } from '@/lib/auth';
-import { getProfile } from '@/lib/profile';
+import { getDisplayName, getProfile } from '@/lib/profile';
 
 import { signOut } from '../actions';
+import { AvatarUploader } from './avatar-uploader';
 import { ProfileForm } from './profile-form';
 
 interface ProfilePageProps {
@@ -37,6 +38,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
 
   const user = await requireUser(typedLocale);
   const profile = await getProfile();
+  const displayName = getDisplayName(profile, user);
   const t = await getTranslations({ locale: typedLocale, namespace: 'profile' });
 
   return (
@@ -63,6 +65,21 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           </button>
         </form>
       </header>
+
+      <section className="mb-8 border-2 border-foreground p-8">
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('avatar.label')}
+        </p>
+        <h2 className="mt-3 mb-6 font-display text-2xl leading-snug text-foreground">
+          {t('avatar.heading')}
+        </h2>
+
+        <AvatarUploader
+          locale={typedLocale}
+          displayName={displayName}
+          initialAvatarUrl={profile?.avatar_url ?? null}
+        />
+      </section>
 
       <section className="border-2 border-foreground p-8">
         <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -22,6 +22,12 @@ interface AvatarProps {
   size?: Size;
   /** Classe Tailwind additionnelle. */
   className?: string;
+  /**
+   * Si l'avatar est accolé à un texte qui nomme déjà la personne (ex. pseudo
+   * dans un même `<Link>`), passer `decorative` pour éviter la duplication
+   * pour les lecteurs d'écran.
+   */
+  decorative?: boolean;
 }
 
 /**
@@ -36,6 +42,7 @@ export function Avatar({
   displayName,
   size = 'md',
   className = '',
+  decorative = false,
 }: AvatarProps) {
   const px = SIZE_PX[size];
   const initials = initialsFor(displayName);
@@ -51,11 +58,15 @@ export function Avatar({
 
   if (src) {
     return (
-      <span className={`${base} ${className}`.trim()} style={style}>
+      <span
+        className={`${base} ${className}`.trim()}
+        style={style}
+        {...(decorative ? { 'aria-hidden': true } : {})}
+      >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={src}
-          alt={displayName}
+          alt={decorative ? '' : displayName}
           width={px}
           height={px}
           loading="lazy"
@@ -70,7 +81,9 @@ export function Avatar({
     <span
       className={`${base} ${SIZE_TEXT[size]} ${className}`.trim()}
       style={style}
-      aria-label={displayName}
+      {...(decorative
+        ? { 'aria-hidden': true }
+        : { 'aria-label': displayName })}
     >
       {initials}
     </span>

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -1,0 +1,78 @@
+import { initialsFor } from '@/lib/profile/avatar';
+
+type Size = 'sm' | 'md' | 'lg' | 'xl';
+
+const SIZE_PX: Record<Size, number> = {
+  sm: 32,
+  md: 44,
+  lg: 64,
+  xl: 112,
+};
+
+const SIZE_TEXT: Record<Size, string> = {
+  sm: 'text-[11px]',
+  md: 'text-sm',
+  lg: 'text-base',
+  xl: 'text-2xl',
+};
+
+interface AvatarProps {
+  src: string | null | undefined;
+  displayName: string;
+  size?: Size;
+  /** Classe Tailwind additionnelle. */
+  className?: string;
+}
+
+/**
+ * Avatar carré à coins droits (cohérent avec la direction brutaliste du v2).
+ * Fallback initiales sur fond "paper" + bordure "ink" si pas d'image.
+ *
+ * Pour une image optimisée Next.js, on utilisera `<Image />` plus tard ;
+ * pour l'instant `<img>` suffit (avatars Supabase publics, cache-buster).
+ */
+export function Avatar({
+  src,
+  displayName,
+  size = 'md',
+  className = '',
+}: AvatarProps) {
+  const px = SIZE_PX[size];
+  const initials = initialsFor(displayName);
+  const base =
+    'inline-flex shrink-0 items-center justify-center overflow-hidden border-2 font-mono uppercase tracking-widest';
+  const style: React.CSSProperties = {
+    width: px,
+    height: px,
+    borderColor: 'var(--color-foreground)',
+    background: 'var(--color-muted, var(--color-background))',
+    color: 'var(--color-foreground)',
+  };
+
+  if (src) {
+    return (
+      <span className={`${base} ${className}`.trim()} style={style}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={src}
+          alt={displayName}
+          width={px}
+          height={px}
+          loading="lazy"
+          decoding="async"
+          className="h-full w-full object-cover"
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`${base} ${SIZE_TEXT[size]} ${className}`.trim()}
+      style={style}
+      aria-label={displayName}
+    >
+      {initials}
+    </span>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -185,6 +185,16 @@
     "title": "You, in numbers.",
     "lede": "Signed in as {email}. You can change your username and display name at any time.",
     "logout": "Sign out",
+    "avatar": {
+      "label": "PHOTO",
+      "heading": "Your profile picture.",
+      "pick": "Pick a photo",
+      "replace": "Replace photo",
+      "remove": "Remove",
+      "uploading": "Uploading…",
+      "removing": "Removing…",
+      "help": "JPG, PNG, WebP or GIF · 5 MB max · square recommended."
+    },
     "section": {
       "label": "IDENTITY",
       "heading": "How should we call you?"
@@ -211,6 +221,9 @@
       "pseudoTaken": "This username is already taken.",
       "fullNameRequired": "Enter a name or leave empty.",
       "fullNameTooLong": "Name too long (50 chars max).",
+      "avatarTooLarge": "Image too large (5 MB max).",
+      "avatarMimeType": "Unsupported format. JPG, PNG, WebP or GIF.",
+      "avatarUpload": "Upload failed. Try again.",
       "rateLimit": "Too many attempts. Try again in a minute.",
       "generic": "Something went wrong. Try again."
     },

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -300,5 +300,57 @@
       "body": "This magic link no longer works. Request a new one.",
       "cta": "Send a new link"
     }
+  },
+  "legal": {
+    "eyebrow": "LEGAL · IRONTRACK",
+    "nav": {
+      "home": "Home",
+      "privacy": "Privacy",
+      "terms": "Terms"
+    },
+    "draft": {
+      "label": "DRAFT · v2 ALPHA",
+      "body": "This page is a working draft. The final version will be published before v1.0 and will comply with the GDPR (Belgium, EU)."
+    },
+    "privacy": {
+      "title": "Privacy policy.",
+      "lede": "Your data stays yours. IronTrack is hosted in Europe and built GDPR-first.",
+      "collect": {
+        "title": "What we collect",
+        "body": "Strictly the essentials: your email, your training sessions, your metrics. No ad tracking, no third-party analytics. Your avatar is stored in our Supabase Storage in Europe."
+      },
+      "usage": {
+        "title": "How we use it",
+        "body": "To display your progress, sync your sessions between your devices, and secure your account. Never sold. Never shared with third parties for marketing purposes."
+      },
+      "rights": {
+        "title": "Your rights (GDPR)",
+        "body": "Access, correction, deletion, full export, portability. Write to us and we reply within 30 days."
+      },
+      "contact": {
+        "title": "Contact",
+        "body": "privacy@irontrack.app — IronTrack, Belgium."
+      }
+    },
+    "terms": {
+      "title": "Terms of service.",
+      "lede": "The rules of the game. Plain language, no dark patterns.",
+      "service": {
+        "title": "The service",
+        "body": "IronTrack is a training, progress and nutrition tracker. Free during the alpha. Paid plans will be announced transparently, no auto-enrolment."
+      },
+      "account": {
+        "title": "Your account",
+        "body": "You are responsible for your password. Report any abuse to us. We may suspend an account in case of abuse (bot, scraping, violation)."
+      },
+      "content": {
+        "title": "Your content",
+        "body": "You own your data. You can export or delete it at any time. We only use it to make the product work for you."
+      },
+      "liability": {
+        "title": "Liability",
+        "body": "IronTrack is not medical advice. Consult a healthcare professional before any intensive programme. The service is provided \"as is\" during the alpha phase."
+      }
+    }
   }
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -185,6 +185,16 @@
     "title": "Toi, en chiffres.",
     "lede": "Connecté en tant que {email}. Tu peux changer ton pseudo et ton nom à tout moment.",
     "logout": "Se déconnecter",
+    "avatar": {
+      "label": "PHOTO",
+      "heading": "Ta photo de profil.",
+      "pick": "Choisir une photo",
+      "replace": "Remplacer la photo",
+      "remove": "Supprimer",
+      "uploading": "Envoi…",
+      "removing": "Suppression…",
+      "help": "JPG, PNG, WebP ou GIF · 5 Mo max · carré conseillé."
+    },
     "section": {
       "label": "IDENTITÉ",
       "heading": "Comment tu veux qu'on t'appelle ?"
@@ -211,6 +221,9 @@
       "pseudoTaken": "Ce pseudo est déjà pris.",
       "fullNameRequired": "Entre un nom ou laisse vide.",
       "fullNameTooLong": "Nom trop long (50 caractères max).",
+      "avatarTooLarge": "Image trop lourde (5 Mo max).",
+      "avatarMimeType": "Format non supporté. JPG, PNG, WebP ou GIF.",
+      "avatarUpload": "Impossible d'envoyer la photo. Réessaie.",
       "rateLimit": "Trop de tentatives. Réessaie dans une minute.",
       "generic": "Une erreur est survenue. Réessaie."
     },

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1,6 +1,11 @@
 {
-  "brand": { "name": "IronTrack", "tagline": "Train heavier, live lighter." },
-  "common": { "scrollToTop": "Retour en haut" },
+  "brand": {
+    "name": "IronTrack",
+    "tagline": "Train heavier, live lighter."
+  },
+  "common": {
+    "scrollToTop": "Retour en haut"
+  },
   "nav": {
     "home": "Accueil",
     "workouts": "Séances",
@@ -14,17 +19,29 @@
     "eyebrow": "IRONTRACK · v2 · 2026",
     "hero": {
       "kicker": "Masterclass redesign",
-      "train": "Train",
-      "heavier": "heavier,",
-      "live": "live",
-      "lighter": "lighter."
+      "train": "Soulève",
+      "heavier": "plus lourd,",
+      "live": "vis",
+      "lighter": "plus léger."
     },
     "lede": "Une app fitness pensée comme un carnet d'atelier : précise, éditoriale, brutaliste. Pas de confettis. Pas de jargon. Juste ton corps, tes chiffres, ton progrès.",
     "meta": {
-      "stack": { "label": "Stack", "value": "Next 16" },
-      "backend": { "label": "Backend", "value": "Supabase" },
-      "budget": { "label": "Budget", "value": "0 €" },
-      "target": { "label": "Cible", "value": "Hevy · Strava · Whoop" }
+      "stack": {
+        "label": "Stack",
+        "value": "Next 16"
+      },
+      "backend": {
+        "label": "Backend",
+        "value": "Supabase"
+      },
+      "budget": {
+        "label": "Budget",
+        "value": "0 €"
+      },
+      "target": {
+        "label": "Cible",
+        "value": "Hevy · Strava · Whoop"
+      }
     },
     "build": {
       "heading": "On construit",
@@ -58,10 +75,10 @@
     "eyebrow": "IRONTRACK · 2026 · MADE IN BELGIUM",
     "hero": {
       "kicker": "Le carnet d'atelier de ton entraînement",
-      "train": "Train",
-      "heavier": "heavier,",
-      "live": "live",
-      "lighter": "lighter.",
+      "train": "Soulève",
+      "heavier": "plus lourd,",
+      "live": "vis",
+      "lighter": "plus léger.",
       "lede": "Suis chaque rep, chaque watt, chaque calorie. Sans bullshit. Sans pub. Sans gamification creuse. Juste tes chiffres et ta progression.",
       "cta": {
         "start": "Créer mon compte gratuit",
@@ -299,6 +316,58 @@
       "title": "Lien invalide ou expiré.",
       "body": "Ce lien magique ne fonctionne plus. Demande-en un nouveau.",
       "cta": "Renvoyer un lien"
+    }
+  },
+  "legal": {
+    "eyebrow": "LÉGAL · IRONTRACK",
+    "nav": {
+      "home": "Accueil",
+      "privacy": "Vie privée",
+      "terms": "Conditions"
+    },
+    "draft": {
+      "label": "BROUILLON · v2 ALPHA",
+      "body": "Cette page est un brouillon de travail. La version finale sera publiée avant la v1.0 et sera conforme au RGPD (Belgique, UE)."
+    },
+    "privacy": {
+      "title": "Politique de confidentialité.",
+      "lede": "Tes données restent à toi. IronTrack est hébergé en Europe et pensé RGPD-first.",
+      "collect": {
+        "title": "Ce qu'on collecte",
+        "body": "Strictement l'essentiel : ton email, tes séances, tes métriques. Aucun tracking publicitaire, aucune analytique tierce. Ton avatar est stocké sur notre Supabase Storage en Europe."
+      },
+      "usage": {
+        "title": "Comment on l'utilise",
+        "body": "Pour afficher ta progression, synchroniser tes séances entre tes appareils et sécuriser ton compte. Jamais revendu. Jamais partagé avec des tiers à des fins marketing."
+      },
+      "rights": {
+        "title": "Tes droits (RGPD)",
+        "body": "Accès, rectification, effacement, export complet, portabilité. Tu nous écris et on répond sous 30 jours."
+      },
+      "contact": {
+        "title": "Contact",
+        "body": "privacy@irontrack.app — IronTrack, Belgique."
+      }
+    },
+    "terms": {
+      "title": "Conditions d'utilisation.",
+      "lede": "Les règles du jeu. Langage clair, pas de dark patterns.",
+      "service": {
+        "title": "Le service",
+        "body": "IronTrack est un suivi d'entraînement, de progression et de nutrition. Gratuit pendant l'alpha. Les formules payantes seront annoncées en toute transparence, sans reconduction automatique."
+      },
+      "account": {
+        "title": "Ton compte",
+        "body": "Tu es responsable de ton mot de passe. Signale-nous tout abus. On peut suspendre un compte en cas d'abus (bot, scraping, violation)."
+      },
+      "content": {
+        "title": "Tes contenus",
+        "body": "Tu es propriétaire de tes données. Tu peux les exporter ou les supprimer à tout moment. On ne les utilise que pour faire fonctionner le produit pour toi."
+      },
+      "liability": {
+        "title": "Responsabilité",
+        "body": "IronTrack n'est pas un avis médical. Consulte un professionnel de santé avant tout programme intensif. Le service est fourni \"en l'état\" pendant la phase alpha."
+      }
     }
   }
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -1,6 +1,11 @@
 {
-  "brand": { "name": "IronTrack", "tagline": "Train zwaarder, leef lichter." },
-  "common": { "scrollToTop": "Terug naar boven" },
+  "brand": {
+    "name": "IronTrack",
+    "tagline": "Train zwaarder, leef lichter."
+  },
+  "common": {
+    "scrollToTop": "Terug naar boven"
+  },
   "nav": {
     "home": "Start",
     "workouts": "Sessies",
@@ -21,10 +26,22 @@
     },
     "lede": "Een fitness-app gebouwd als een atelierboek: precies, redactioneel, brutalistisch. Geen confetti. Geen jargon. Enkel jouw lichaam, jouw cijfers, jouw vooruitgang.",
     "meta": {
-      "stack": { "label": "Stack", "value": "Next 16" },
-      "backend": { "label": "Backend", "value": "Supabase" },
-      "budget": { "label": "Budget", "value": "0 €" },
-      "target": { "label": "Doel", "value": "Hevy · Strava · Whoop" }
+      "stack": {
+        "label": "Stack",
+        "value": "Next 16"
+      },
+      "backend": {
+        "label": "Backend",
+        "value": "Supabase"
+      },
+      "budget": {
+        "label": "Budget",
+        "value": "0 €"
+      },
+      "target": {
+        "label": "Doel",
+        "value": "Hevy · Strava · Whoop"
+      }
     },
     "build": {
       "heading": "We bouwen",
@@ -299,6 +316,58 @@
       "title": "Ongeldige of verlopen link.",
       "body": "Deze magic link werkt niet meer. Vraag een nieuwe aan.",
       "cta": "Nieuwe link sturen"
+    }
+  },
+  "legal": {
+    "eyebrow": "JURIDISCH · IRONTRACK",
+    "nav": {
+      "home": "Home",
+      "privacy": "Privacy",
+      "terms": "Voorwaarden"
+    },
+    "draft": {
+      "label": "CONCEPT · v2 ALPHA",
+      "body": "Deze pagina is een werkversie. De definitieve versie wordt gepubliceerd vóór v1.0 en zal voldoen aan de AVG (België, EU)."
+    },
+    "privacy": {
+      "title": "Privacybeleid.",
+      "lede": "Je gegevens blijven van jou. IronTrack wordt in Europa gehost en is AVG-first ontworpen.",
+      "collect": {
+        "title": "Wat we verzamelen",
+        "body": "Strikt het essentiële: je e-mail, je sessies, je metrics. Geen advertentietracking, geen externe analytics. Je avatar staat op onze Supabase Storage in Europa."
+      },
+      "usage": {
+        "title": "Hoe we het gebruiken",
+        "body": "Om je progressie te tonen, je sessies te synchroniseren tussen je toestellen en je account te beveiligen. Nooit verkocht. Nooit gedeeld met derden voor marketing."
+      },
+      "rights": {
+        "title": "Je rechten (AVG)",
+        "body": "Inzage, rectificatie, verwijdering, volledige export, portabiliteit. Je schrijft ons en we antwoorden binnen 30 dagen."
+      },
+      "contact": {
+        "title": "Contact",
+        "body": "privacy@irontrack.app — IronTrack, België."
+      }
+    },
+    "terms": {
+      "title": "Gebruiksvoorwaarden.",
+      "lede": "De spelregels. Klare taal, geen dark patterns.",
+      "service": {
+        "title": "De dienst",
+        "body": "IronTrack is een tracker voor training, progressie en voeding. Gratis tijdens de alpha. Betaalde plannen worden transparant aangekondigd, zonder automatische verlenging."
+      },
+      "account": {
+        "title": "Je account",
+        "body": "Jij bent verantwoordelijk voor je wachtwoord. Meld misbruik aan ons. We kunnen een account opschorten bij misbruik (bot, scraping, inbreuk)."
+      },
+      "content": {
+        "title": "Jouw inhoud",
+        "body": "Jij bent eigenaar van je data. Je kan die op elk moment exporteren of verwijderen. We gebruiken ze enkel om het product voor jou te laten werken."
+      },
+      "liability": {
+        "title": "Aansprakelijkheid",
+        "body": "IronTrack is geen medisch advies. Raadpleeg een zorgverlener vóór elk intensief programma. De dienst wordt \"as is\" geleverd tijdens de alpha."
+      }
     }
   }
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -185,6 +185,16 @@
     "title": "Jij, in cijfers.",
     "lede": "Aangemeld als {email}. Je kunt je pseudoniem en je naam op elk moment wijzigen.",
     "logout": "Afmelden",
+    "avatar": {
+      "label": "FOTO",
+      "heading": "Je profielfoto.",
+      "pick": "Foto kiezen",
+      "replace": "Foto vervangen",
+      "remove": "Verwijderen",
+      "uploading": "Uploaden…",
+      "removing": "Verwijderen…",
+      "help": "JPG, PNG, WebP of GIF · max 5 MB · vierkant aanbevolen."
+    },
     "section": {
       "label": "IDENTITEIT",
       "heading": "Hoe moeten we je noemen?"
@@ -211,6 +221,9 @@
       "pseudoTaken": "Dit pseudoniem is al in gebruik.",
       "fullNameRequired": "Vul een naam in of laat leeg.",
       "fullNameTooLong": "Naam te lang (max 50 tekens).",
+      "avatarTooLarge": "Afbeelding te groot (max 5 MB).",
+      "avatarMimeType": "Niet-ondersteund formaat. JPG, PNG, WebP of GIF.",
+      "avatarUpload": "Uploaden mislukt. Probeer opnieuw.",
       "rateLimit": "Te veel pogingen. Probeer het over een minuut opnieuw.",
       "generic": "Er is iets misgegaan. Probeer opnieuw."
     },

--- a/src/lib/profile/avatar.ts
+++ b/src/lib/profile/avatar.ts
@@ -1,0 +1,68 @@
+/**
+ * Constantes + helpers avatar (partagés client + serveur).
+ *
+ * Le bucket Supabase `avatars` est public et accepte image/jpeg, image/png,
+ * image/webp, image/gif avec une limite de 5 MB (configuré côté Supabase).
+ * Les policies RLS imposent que le chemin commence par `${auth.uid()}/`.
+ */
+
+export const AVATAR_BUCKET = 'avatars';
+
+export const AVATAR_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export const AVATAR_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+] as const;
+
+export type AvatarMimeType = (typeof AVATAR_MIME_TYPES)[number];
+
+const EXT_BY_MIME: Record<AvatarMimeType, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+};
+
+export function isAvatarMimeType(mime: string): mime is AvatarMimeType {
+  return (AVATAR_MIME_TYPES as readonly string[]).includes(mime);
+}
+
+export function avatarExtFor(mime: AvatarMimeType): string {
+  return EXT_BY_MIME[mime];
+}
+
+/**
+ * Construit un chemin safe pour un nouvel avatar.
+ * Format : `${userId}/${uuid}.${ext}` — RLS storage le requiert.
+ */
+export function buildAvatarPath(userId: string, mime: AvatarMimeType): string {
+  const uuid = crypto.randomUUID();
+  return `${userId}/${uuid}.${avatarExtFor(mime)}`;
+}
+
+/**
+ * Extrait le path Storage (`userId/uuid.ext`) depuis une URL publique Supabase.
+ * Retourne `null` si ce n'est pas une URL du bucket `avatars`.
+ */
+export function pathFromPublicUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const marker = `/storage/v1/object/public/${AVATAR_BUCKET}/`;
+  const idx = url.indexOf(marker);
+  if (idx < 0) return null;
+  return url.slice(idx + marker.length).split('?')[0] ?? null;
+}
+
+/**
+ * Initiales (1 ou 2 lettres max) à afficher dans l'Avatar quand pas d'image.
+ */
+export function initialsFor(displayName: string): string {
+  const s = displayName.trim();
+  if (!s) return '?';
+  const parts = s.split(/[\s_.-]+/).filter(Boolean);
+  if (parts.length === 0) return s.slice(0, 1).toUpperCase();
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
+  return (parts[0]![0]! + parts[1]![0]!).toUpperCase();
+}


### PR DESCRIPTION
## Summary
- Server actions `uploadAvatar` / `removeAvatar` (validation taille + mime, rate-limit, path RLS-safe, cleanup ancien fichier).
- Helper `src/lib/profile/avatar.ts` (constantes, `buildAvatarPath`, `pathFromPublicUrl`, `initialsFor`).
- `<Avatar>` : carré brutaliste avec fallback initiales.
- `<AvatarUploader>` client (double validation, preview optimiste, boutons pick/replace/remove).
- Wire : `/profile` section photo, header dashboard (cliquable → /profile), hero home (badge displayName + avatar).
- i18n FR/NL/EN.

## Stacking
Base : `feature/profile` (PR #42). À merger après #42.

## Storage
Bucket `avatars` Supabase + RLS déjà en place (legacy v1). Policies :
- SELECT : tout le monde (bucket public)
- INSERT/UPDATE/DELETE : `auth.uid()::text = storage.foldername(name)[1]`

Pas de migration SQL nécessaire.

## Sécurité
- Double validation (client UX + serveur autoritatif) : 5 MB max, jpeg/png/webp/gif only
- Path forcé `${userId}/uuid.ext` côté serveur (évite path traversal / override d'autres users)
- Rate-limit 5 / 60s par IP
- Auth check obligatoire, redirect vers login si absent
- Rollback : si l'update `profiles.avatar_url` échoue après upload, le fichier est retiré

## Test plan
- [ ] `/fr/profile` : upload JPG 200 Ko → avatar apparaît, dashboard affiche le nouvel avatar
- [ ] Upload fichier > 5 MB → erreur client sans aller-retour serveur
- [ ] Upload PDF → erreur mime type
- [ ] "Supprimer" → avatar redevient initiales, storage cleané
- [ ] Remplacer : upload une 2e image → ancienne supprimée du bucket
- [ ] Hero home (connecté) affiche l'avatar cliquable vers /profile
- [ ] Fallback initiales : `thierryvm@gmail.com` → "TH"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ajout de fonctionnalités de téléversement et d’affichage d’avatar sur les pages de profil, tableau de bord et accueil, basées sur le stockage Supabase et une gestion localisée des erreurs.

Nouvelles fonctionnalités :
- Introduction d’actions serveur pour téléverser et supprimer les avatars des utilisateurs stockés dans un bucket Supabase `avatars`, avec validation et limitation de débit.
- Ajout d’un composant Avatar carré réutilisable avec remplacement par initiales et plusieurs variantes de taille pour un affichage cohérent des avatars.
- Ajout d’un composant client AvatarUploader sur la page de profil avec aperçu optimiste, validation côté client, et flux de suppression/remplacement.
- Affichage de l’avatar de l’utilisateur actuel dans l’en-tête du tableau de bord et le hero de la page d’accueil, avec lien vers la page de profil.

Améliorations :
- Extension de l’état des actions de profil pour couvrir les erreurs et champs spécifiques à l’avatar, avec des messages localisés dans toutes les langues prises en charge.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add avatar upload and display capabilities across the profile, dashboard, and home pages, backed by Supabase storage and localized error handling.

New Features:
- Introduce server actions to upload and remove user avatars stored in a Supabase `avatars` bucket with validation and rate limiting.
- Add a reusable square Avatar component with initials fallback and multiple size variants for consistent avatar display.
- Add a client-side AvatarUploader component on the profile page with optimistic preview, client-side validation, and remove/replace flows.
- Display the current user avatar in the dashboard header and home hero, linking to the profile page.

Enhancements:
- Extend profile action state to cover avatar-specific errors and fields, with localized messaging in all supported locales.

</details>