### PR TITLE
feat(dashboard): real data (streak, 7 derniers jours, historique, dernière perf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,7 @@ kill-port.ps1
 restart-dev.bat
 .jest-worker-patched
 node_modules/.cache
+
+# ─── Artefacts tests/screenshots locaux ──────────────────────
+.playwright-mcp/
+/*.png

--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -4,6 +4,12 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { Avatar } from '@/components/avatar';
 import { LOCALES, type Locale } from '@/i18n/request';
 import { requireUser } from '@/lib/auth';
+import { getDashboardStats } from '@/lib/dashboard';
+import {
+  formatDistance,
+  formatDuration,
+  formatRelativeDate,
+} from '@/lib/dashboard/format';
 import { getDisplayName, getProfile, needsProfileOnboarding } from '@/lib/profile';
 
 import { signOut } from '../actions';
@@ -22,8 +28,12 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
     ? (locale as Locale)
     : 'fr';
   setRequestLocale(typedLocale);
+
   const user = await requireUser(typedLocale);
-  const profile = await getProfile();
+  const [profile, stats] = await Promise.all([
+    getProfile(),
+    getDashboardStats(user.id),
+  ]);
   const displayName = getDisplayName(profile, user);
   const showOnboarding = needsProfileOnboarding(profile);
 
@@ -31,6 +41,12 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
     locale: typedLocale,
     namespace: 'dashboard',
   });
+
+  const hasAnyData =
+    stats.streak.current > 0 ||
+    stats.sevenDaysWorkouts > 0 ||
+    stats.recentWorkouts.length > 0 ||
+    stats.lastPerformance !== null;
 
   return (
     <main className="mx-auto max-w-4xl px-6 py-16">
@@ -95,28 +111,196 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
         </section>
       )}
 
-      <section className="border-2 border-foreground p-8">
-        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
-          {t('placeholder.label')}
-        </p>
-        <p className="mt-3 font-display text-2xl leading-snug text-foreground">
-          {t('placeholder.body')}
-        </p>
-        <div className="mt-6 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
-          <Link
-            href={`/${typedLocale}/profile`}
-            className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
-          >
-            {t('profileLink')} →
-          </Link>
-          <Link
-            href={`/${typedLocale}`}
-            className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
-          >
-            ← {t('back')}
-          </Link>
-        </div>
+      {!hasAnyData && !showOnboarding && (
+        <section className="mb-10 border-2 border-foreground p-8 text-center">
+          <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('empty.label')}
+          </p>
+          <p className="mt-3 font-display text-2xl leading-snug text-foreground">
+            {t('empty.body')}
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {t('empty.subtext')}
+          </p>
+        </section>
+      )}
+
+      {/* Stats grid : streak + 7 days */}
+      <section
+        aria-labelledby="stats-heading"
+        className="mb-8 grid gap-6 sm:grid-cols-2"
+      >
+        <h2 id="stats-heading" className="sr-only">
+          {t('stats.heading')}
+        </h2>
+
+        {/* Streak */}
+        <article className="border-2 border-foreground p-6">
+          <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('stats.streak.label')}
+          </p>
+          <p className="mt-4 font-display text-5xl leading-none text-foreground">
+            {stats.streak.current}
+          </p>
+          <p className="mt-2 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('stats.streak.days', { count: stats.streak.current })}
+          </p>
+          {stats.streak.max > 0 && (
+            <p className="mt-4 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+              {t('stats.streak.record', { count: stats.streak.max })}
+            </p>
+          )}
+        </article>
+
+        {/* 7 jours */}
+        <article className="border-2 border-foreground p-6">
+          <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('stats.sevenDays.label')}
+          </p>
+          <p className="mt-4 font-display text-5xl leading-none text-foreground">
+            {stats.sevenDaysWorkouts}
+          </p>
+          <p className="mt-2 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('stats.sevenDays.workouts', {
+              count: stats.sevenDaysWorkouts,
+            })}
+          </p>
+          <p className="mt-4 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('stats.sevenDays.subtext')}
+          </p>
+        </article>
       </section>
+
+      {/* Dernière performance */}
+      {stats.lastPerformance && (
+        <section className="mb-8 border-2 border-foreground p-6">
+          <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('stats.lastPerformance.label')}
+          </p>
+          <h2 className="mt-3 font-display text-2xl leading-snug text-foreground">
+            {stats.lastPerformance.exerciseName}
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {formatRelativeDate(
+              stats.lastPerformance.performedAt,
+              typedLocale,
+            )}
+          </p>
+          <dl className="mt-4 flex flex-wrap gap-x-8 gap-y-3 font-mono text-xs uppercase tracking-widest">
+            {stats.lastPerformance.weightKg !== null && (
+              <div>
+                <dt className="text-muted-foreground">
+                  {t('stats.lastPerformance.weight')}
+                </dt>
+                <dd className="mt-1 font-display text-lg text-foreground">
+                  {stats.lastPerformance.weightKg} kg
+                </dd>
+              </div>
+            )}
+            {stats.lastPerformance.reps !== null && (
+              <div>
+                <dt className="text-muted-foreground">
+                  {t('stats.lastPerformance.reps')}
+                </dt>
+                <dd className="mt-1 font-display text-lg text-foreground">
+                  {stats.lastPerformance.reps}
+                </dd>
+              </div>
+            )}
+            {formatDistance(
+              stats.lastPerformance.distanceMeters,
+              stats.lastPerformance.distanceUnit,
+              typedLocale,
+            ) && (
+              <div>
+                <dt className="text-muted-foreground">
+                  {t('stats.lastPerformance.distance')}
+                </dt>
+                <dd className="mt-1 font-display text-lg text-foreground">
+                  {formatDistance(
+                    stats.lastPerformance.distanceMeters,
+                    stats.lastPerformance.distanceUnit,
+                    typedLocale,
+                  )}
+                </dd>
+              </div>
+            )}
+            {stats.lastPerformance.durationSeconds !== null &&
+              stats.lastPerformance.durationSeconds > 0 && (
+                <div>
+                  <dt className="text-muted-foreground">
+                    {t('stats.lastPerformance.duration')}
+                  </dt>
+                  <dd className="mt-1 font-display text-lg text-foreground">
+                    {formatDuration(
+                      stats.lastPerformance.durationSeconds,
+                      typedLocale,
+                    )}
+                  </dd>
+                </div>
+              )}
+          </dl>
+        </section>
+      )}
+
+      {/* Dernières séances */}
+      <section className="mb-10 border-2 border-foreground p-6">
+        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('stats.recentWorkouts.label')}
+        </p>
+        <h2 className="mt-3 mb-6 font-display text-2xl leading-snug text-foreground">
+          {t('stats.recentWorkouts.heading')}
+        </h2>
+
+        {stats.recentWorkouts.length === 0 ? (
+          <p className="text-base text-muted-foreground">
+            {t('stats.recentWorkouts.empty')}
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {stats.recentWorkouts.map((w) => (
+              <li
+                key={w.id}
+                className="flex flex-col gap-1 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+              >
+                <div className="min-w-0">
+                  <p className="font-display text-lg leading-snug text-foreground break-words">
+                    {w.name}
+                  </p>
+                  {w.type && (
+                    <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+                      {w.type}
+                    </p>
+                  )}
+                </div>
+                <div className="flex flex-col gap-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground sm:text-right">
+                  <span>{formatRelativeDate(w.endTime, typedLocale)}</span>
+                  {w.durationSeconds !== null && w.durationSeconds > 0 && (
+                    <span>
+                      {formatDuration(w.durationSeconds, typedLocale)}
+                    </span>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <nav className="mt-10 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
+        <Link
+          href={`/${typedLocale}/profile`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          {t('profileLink')} →
+        </Link>
+        <Link
+          href={`/${typedLocale}`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          ← {t('back')}
+        </Link>
+      </nav>
     </main>
   );
 }

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -31,7 +31,8 @@ interface AvatarProps {
 }
 
 /**
- * Avatar carré à coins droits (cohérent avec la direction brutaliste du v2).
+ * Avatar circulaire avec bordure "ink" épaisse (clin d'œil brutaliste mais
+ * forme ronde demandée par l'utilisateur).
  * Fallback initiales sur fond "paper" + bordure "ink" si pas d'image.
  *
  * Pour une image optimisée Next.js, on utilisera `<Image />` plus tard ;
@@ -47,7 +48,7 @@ export function Avatar({
   const px = SIZE_PX[size];
   const initials = initialsFor(displayName);
   const base =
-    'inline-flex shrink-0 items-center justify-center overflow-hidden border-2 font-mono uppercase tracking-widest';
+    'inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border-2 font-mono uppercase tracking-widest';
   const style: React.CSSProperties = {
     width: px,
     height: px,

--- a/src/components/scroll-to-top.tsx
+++ b/src/components/scroll-to-top.tsx
@@ -8,10 +8,21 @@ export function ScrollToTop() {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 600);
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
+    const update = () => {
+      // Ne s'affiche que si (1) la page est réellement plus longue que le
+      // viewport + un seuil utile, et (2) l'utilisateur a scrollé. Sinon sur
+      // les pages courtes (login, erreurs) le bouton apparaissait à tort.
+      const doc = document.documentElement;
+      const scrollable = doc.scrollHeight - window.innerHeight > 600;
+      setVisible(scrollable && window.scrollY > 600);
+    };
+    update();
+    window.addEventListener('scroll', update, { passive: true });
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('scroll', update);
+      window.removeEventListener('resize', update);
+    };
   }, []);
 
   return (

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -173,9 +173,35 @@
       "body": "Pick a username to personalise your space — and, later, train alongside partners.",
       "cta": "Complete my profile"
     },
-    "placeholder": {
-      "label": "COMING NEXT",
-      "body": "The real dashboard is on its way: your last session, your records, your upcoming sessions, your progress graphs."
+    "empty": {
+      "label": "FIRST SESSION",
+      "body": "No data yet. Log your first session to see your numbers here.",
+      "subtext": "Your streak, records and history will appear once your first session is complete."
+    },
+    "stats": {
+      "heading": "Statistics",
+      "streak": {
+        "label": "STREAK",
+        "days": "{count, plural, =0 {day} one {day in a row} other {days in a row}}",
+        "record": "Record: {count, plural, one {# day} other {# days}}"
+      },
+      "sevenDays": {
+        "label": "LAST 7 DAYS",
+        "workouts": "{count, plural, =0 {session} one {session} other {sessions}}",
+        "subtext": "Sessions completed this week"
+      },
+      "lastPerformance": {
+        "label": "LAST PERFORMANCE",
+        "weight": "Load",
+        "reps": "Reps",
+        "distance": "Distance",
+        "duration": "Duration"
+      },
+      "recentWorkouts": {
+        "label": "HISTORY",
+        "heading": "Your latest sessions.",
+        "empty": "No completed sessions yet."
+      }
     }
   },
   "profile": {

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -190,9 +190,35 @@
       "body": "Choisis un pseudo pour personnaliser ton espace et, plus tard, t'entraîner avec des partenaires.",
       "cta": "Compléter mon profil"
     },
-    "placeholder": {
-      "label": "PROCHAINE ÉTAPE",
-      "body": "Le vrai tableau de bord arrive : ta dernière séance, tes records, tes prochaines sessions, tes graphes de progression."
+    "empty": {
+      "label": "PREMIÈRE SÉANCE",
+      "body": "Pas encore de données. Lance ta première séance pour voir tes chiffres ici.",
+      "subtext": "Ton streak, tes records et ton historique apparaîtront dès ta première session complétée."
+    },
+    "stats": {
+      "heading": "Statistiques",
+      "streak": {
+        "label": "STREAK",
+        "days": "{count, plural, =0 {jour} one {jour d'affilée} other {jours d'affilée}}",
+        "record": "Record : {count, plural, one {# jour} other {# jours}}"
+      },
+      "sevenDays": {
+        "label": "7 DERNIERS JOURS",
+        "workouts": "{count, plural, =0 {séance} one {séance} other {séances}}",
+        "subtext": "Séances complétées cette semaine"
+      },
+      "lastPerformance": {
+        "label": "DERNIÈRE PERFORMANCE",
+        "weight": "Charge",
+        "reps": "Reps",
+        "distance": "Distance",
+        "duration": "Durée"
+      },
+      "recentWorkouts": {
+        "label": "HISTORIQUE",
+        "heading": "Tes dernières séances.",
+        "empty": "Aucune séance complétée pour l'instant."
+      }
     }
   },
   "profile": {

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -190,9 +190,35 @@
       "body": "Kies een pseudoniem om je ruimte te personaliseren en later met trainingspartners te kunnen trainen.",
       "cta": "Profiel aanvullen"
     },
-    "placeholder": {
-      "label": "VOLGENDE STAP",
-      "body": "Het echte dashboard komt eraan: je laatste sessie, je records, je volgende sessies, je voortgangsgrafieken."
+    "empty": {
+      "label": "EERSTE SESSIE",
+      "body": "Nog geen gegevens. Start je eerste sessie om je cijfers hier te zien.",
+      "subtext": "Je streak, records en historiek verschijnen zodra je eerste sessie voltooid is."
+    },
+    "stats": {
+      "heading": "Statistieken",
+      "streak": {
+        "label": "STREAK",
+        "days": "{count, plural, =0 {dag} one {dag op rij} other {dagen op rij}}",
+        "record": "Record: {count, plural, one {# dag} other {# dagen}}"
+      },
+      "sevenDays": {
+        "label": "LAATSTE 7 DAGEN",
+        "workouts": "{count, plural, =0 {sessie} one {sessie} other {sessies}}",
+        "subtext": "Sessies voltooid deze week"
+      },
+      "lastPerformance": {
+        "label": "LAATSTE PRESTATIE",
+        "weight": "Gewicht",
+        "reps": "Reps",
+        "distance": "Afstand",
+        "duration": "Duur"
+      },
+      "recentWorkouts": {
+        "label": "HISTORIEK",
+        "heading": "Je laatste sessies.",
+        "empty": "Nog geen voltooide sessies."
+      }
     }
   },
   "profile": {

--- a/src/lib/dashboard/format.ts
+++ b/src/lib/dashboard/format.ts
@@ -1,0 +1,95 @@
+import type { Locale } from '@/i18n/request';
+
+const INTL_LOCALE: Record<Locale, string> = {
+  fr: 'fr-BE',
+  nl: 'nl-BE',
+  en: 'en-GB',
+};
+
+/**
+ * Formate une date ISO en "il y a 3 jours" / "3 days ago" / "3 dagen geleden".
+ *
+ * Seuils : minutes, heures, jours, semaines, mois. Au-delà d'1 an on bascule
+ * sur une date absolue courte pour rester lisible.
+ *
+ * Attention hydration : cette fonction renvoie un rendu basé sur `Date.now()`
+ * côté SERVEUR. À utiliser uniquement en Server Component pour garder un
+ * rendu stable (pas de drift client/serveur).
+ */
+export function formatRelativeDate(
+  iso: string | null | undefined,
+  locale: Locale,
+  now: Date = new Date(),
+): string {
+  if (!iso) return '—';
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+
+  const diffMs = date.getTime() - now.getTime();
+  const diffSec = Math.round(diffMs / 1000);
+  const absSec = Math.abs(diffSec);
+
+  const rtf = new Intl.RelativeTimeFormat(INTL_LOCALE[locale], {
+    numeric: 'auto',
+    style: 'short',
+  });
+
+  if (absSec < 60) return rtf.format(diffSec, 'second');
+  if (absSec < 3600) return rtf.format(Math.round(diffSec / 60), 'minute');
+  if (absSec < 86400) return rtf.format(Math.round(diffSec / 3600), 'hour');
+  if (absSec < 604800) return rtf.format(Math.round(diffSec / 86400), 'day');
+  if (absSec < 2629800) return rtf.format(Math.round(diffSec / 604800), 'week');
+  if (absSec < 31557600)
+    return rtf.format(Math.round(diffSec / 2629800), 'month');
+
+  // > 1 an : date absolue
+  return new Intl.DateTimeFormat(INTL_LOCALE[locale], {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(date);
+}
+
+/**
+ * Formate une durée en secondes : "45 min" / "1 h 20 min" / "—".
+ */
+export function formatDuration(
+  seconds: number | null | undefined,
+  locale: Locale,
+): string {
+  if (seconds === null || seconds === undefined || seconds <= 0) return '—';
+
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+
+  const hLabel = locale === 'en' ? 'h' : 'h';
+  const mLabel = locale === 'en' ? 'min' : 'min';
+
+  if (h === 0) return `${m} ${mLabel}`;
+  if (m === 0) return `${h} ${hLabel}`;
+  return `${h} ${hLabel} ${m} ${mLabel}`;
+}
+
+/**
+ * Formate une distance. Règles :
+ *  - Si unit = 'm' et distance >= 1000 : convertit en km (3 500 m → 3,5 km)
+ *  - Sinon on garde l'unité d'origine
+ *  - Nombre localisé (virgule en fr/nl, point en en)
+ */
+export function formatDistance(
+  distance: number | null | undefined,
+  unit: string | null | undefined,
+  locale: Locale,
+): string | null {
+  if (distance === null || distance === undefined || distance <= 0) return null;
+
+  const nf = new Intl.NumberFormat(INTL_LOCALE[locale], {
+    maximumFractionDigits: 2,
+  });
+
+  if (unit === 'm' && distance >= 1000) {
+    return `${nf.format(distance / 1000)} km`;
+  }
+  return `${nf.format(distance)} ${unit ?? 'm'}`;
+}

--- a/src/lib/dashboard/index.ts
+++ b/src/lib/dashboard/index.ts
@@ -1,0 +1,150 @@
+import { createServerClient } from '@/lib/supabase';
+
+import {
+  dashboardStatsSchema,
+  type DashboardStats,
+  type LastPerformance,
+  type RecentWorkout,
+} from './schema';
+
+/**
+ * Stats affichées sur le dashboard v2.
+ *
+ * Toutes les queries sont faites via `createServerClient` (cookies utilisateur) :
+ * les RLS Supabase garantissent qu'un user ne voit que ses propres données.
+ *
+ * Pas de service_role, pas de tenant leaking possible.
+ *
+ * En cas d'erreur Supabase, on retombe sur des valeurs vides plutôt que de
+ * faire planter la page — le dashboard doit rester robuste.
+ */
+export async function getDashboardStats(
+  userId: string,
+): Promise<DashboardStats> {
+  const supabase = await createServerClient();
+
+  const sevenDaysAgoISO = new Date(
+    Date.now() - 7 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  // 4 queries en parallèle — 1 round-trip réseau effectif côté Postgres.
+  // Chacune est filtrée par `user_id` redondamment avec la RLS (defense in depth).
+  const [streakRes, sevenDaysRes, recentRes, lastPerfRes] = await Promise.all([
+    supabase
+      .from('workout_streaks')
+      .select('streak, max_streak, last_workout_date')
+      .eq('user_id', userId)
+      .maybeSingle(),
+
+    supabase
+      .from('workouts')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .eq('status', 'completed')
+      .gte('end_time', sevenDaysAgoISO),
+
+    supabase
+      .from('workouts')
+      .select('id, name, end_time, duration, type, status')
+      .eq('user_id', userId)
+      .eq('status', 'completed')
+      .not('end_time', 'is', null)
+      .order('end_time', { ascending: false })
+      .limit(5),
+
+    supabase
+      .from('performance_logs')
+      .select(
+        'performed_at, weight, reps, distance, distance_unit, duration, exercise:exercises(name)',
+      )
+      .eq('user_id', userId)
+      .not('performed_at', 'is', null)
+      .order('performed_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  // --- Streak ---
+  const streak = {
+    current: streakRes.data?.streak ?? 0,
+    max: streakRes.data?.max_streak ?? 0,
+    lastWorkoutDate: streakRes.data?.last_workout_date ?? null,
+  };
+  if (streakRes.error) {
+    console.error('[dashboard] streak query failed:', streakRes.error.message);
+  }
+
+  // --- 7 days count ---
+  const sevenDaysWorkouts = sevenDaysRes.count ?? 0;
+  if (sevenDaysRes.error) {
+    console.error(
+      '[dashboard] sevenDays query failed:',
+      sevenDaysRes.error.message,
+    );
+  }
+
+  // --- Recent workouts ---
+  const recentWorkouts: RecentWorkout[] = (recentRes.data ?? []).map((w) => ({
+    id: w.id,
+    name: w.name,
+    endTime: w.end_time,
+    durationSeconds: w.duration,
+    type: w.type,
+  }));
+  if (recentRes.error) {
+    console.error('[dashboard] recent query failed:', recentRes.error.message);
+  }
+
+  // --- Last performance ---
+  let lastPerformance: LastPerformance | null = null;
+  if (lastPerfRes.data) {
+    const exerciseRel = lastPerfRes.data.exercise as
+      | { name: string }
+      | { name: string }[]
+      | null;
+    const exerciseName = Array.isArray(exerciseRel)
+      ? (exerciseRel[0]?.name ?? 'Exercise')
+      : (exerciseRel?.name ?? 'Exercise');
+
+    lastPerformance = {
+      exerciseName,
+      performedAt: lastPerfRes.data.performed_at,
+      weightKg: lastPerfRes.data.weight,
+      reps: lastPerfRes.data.reps,
+      distanceMeters: lastPerfRes.data.distance,
+      distanceUnit: lastPerfRes.data.distance_unit,
+      durationSeconds: lastPerfRes.data.duration,
+    };
+  }
+  if (lastPerfRes.error) {
+    console.error(
+      '[dashboard] lastPerf query failed:',
+      lastPerfRes.error.message,
+    );
+  }
+
+  // Validation défensive : si la forme est inattendue on log et on renvoie vide.
+  const parsed = dashboardStatsSchema.safeParse({
+    streak,
+    sevenDaysWorkouts,
+    recentWorkouts,
+    lastPerformance,
+  });
+
+  if (!parsed.success) {
+    console.error(
+      '[dashboard] schema validation failed:',
+      parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+    );
+    return {
+      streak: { current: 0, max: 0, lastWorkoutDate: null },
+      sevenDaysWorkouts: 0,
+      recentWorkouts: [],
+      lastPerformance: null,
+    };
+  }
+
+  return parsed.data;
+}
+
+export type { DashboardStats, RecentWorkout, LastPerformance } from './schema';

--- a/src/lib/dashboard/index.ts
+++ b/src/lib/dashboard/index.ts
@@ -8,6 +8,13 @@ import {
 } from './schema';
 
 /**
+ * Statuts "séance terminée" côté legacy IronTrack v1 (contrainte CHECK sur la
+ * colonne `workouts.status`). On garde les deux valeurs pour rester rétro-compat.
+ * Toute normalisation future (vers 'completed') se fera via migration.
+ */
+const COMPLETED_STATUSES = ['Terminé', 'Réalisé'] as const;
+
+/**
  * Stats affichées sur le dashboard v2.
  *
  * Toutes les queries sont faites via `createServerClient` (cookies utilisateur) :
@@ -40,14 +47,14 @@ export async function getDashboardStats(
       .from('workouts')
       .select('id', { count: 'exact', head: true })
       .eq('user_id', userId)
-      .eq('status', 'completed')
+      .in('status', COMPLETED_STATUSES)
       .gte('end_time', sevenDaysAgoISO),
 
     supabase
       .from('workouts')
       .select('id, name, end_time, duration, type, status')
       .eq('user_id', userId)
-      .eq('status', 'completed')
+      .in('status', COMPLETED_STATUSES)
       .not('end_time', 'is', null)
       .order('end_time', { ascending: false })
       .limit(5),

--- a/src/lib/dashboard/schema.ts
+++ b/src/lib/dashboard/schema.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+/**
+ * Schémas Zod pour valider les sorties des queries dashboard.
+ *
+ * On valide DÉFENSIVEMENT en sortie de Supabase : le type généré reflète le
+ * schéma mais pas les règles métier (ex: `status` est `string | null` en base
+ * alors qu'on attend 'completed'|'in_progress'|…). Une query qui renvoie des
+ * données inattendues doit être loggée, pas faire planter la page.
+ */
+
+export const recentWorkoutSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  endTime: z.string().datetime().nullable(),
+  durationSeconds: z.number().int().nonnegative().nullable(),
+  type: z.string().nullable(),
+});
+
+export const lastPerformanceSchema = z.object({
+  exerciseName: z.string(),
+  performedAt: z.string().datetime().nullable(),
+  weightKg: z.number().nullable(),
+  reps: z.number().int().nullable(),
+  distanceMeters: z.number().nullable(),
+  distanceUnit: z.string().nullable(),
+  durationSeconds: z.number().int().nonnegative().nullable(),
+});
+
+export const dashboardStatsSchema = z.object({
+  streak: z.object({
+    current: z.number().int().nonnegative(),
+    max: z.number().int().nonnegative(),
+    lastWorkoutDate: z.string().date().nullable(),
+  }),
+  sevenDaysWorkouts: z.number().int().nonnegative(),
+  recentWorkouts: z.array(recentWorkoutSchema).max(5),
+  lastPerformance: lastPerformanceSchema.nullable(),
+});
+
+export type RecentWorkout = z.infer<typeof recentWorkoutSchema>;
+export type LastPerformance = z.infer<typeof lastPerformanceSchema>;
+export type DashboardStats = z.infer<typeof dashboardStatsSchema>;


### PR DESCRIPTION
## Summary
- Dashboard passe du placeholder aux **vraies données Supabase** : streak, 7 derniers jours, dernière performance, historique des 5 dernières séances.
- Nouveau module `src/lib/dashboard/` : query + validation Zod défensive + formatters (date relative / durée / distance) localisés fr-BE / nl-BE / en-GB.
- Empty state incitatif pour les nouveaux utilisateurs (avant première séance).

## Sécurité
- ✅ `createServerClient()` uniquement — jamais de `service_role` côté page
- ✅ `eq('user_id', userId)` en plus de la RLS (defense in depth)
- ✅ RLS vérifiée sur `workouts`, `performance_logs`, `workout_streaks` (policies `auth.uid() = user_id` sur SELECT)
- ✅ Pas d'email/ID dans les logs d'erreur
- ✅ Try/catch + fallback vide — si Supabase est down, la page affiche `0` / `—` au lieu de planter

## Architecture
- `lib/dashboard/index.ts` — orchestration (4 queries parallèles)
- `lib/dashboard/schema.ts` — Zod en sortie (sécurité contre des retours inattendus)
- `lib/dashboard/format.ts` — Intl.RelativeTimeFormat + Intl.NumberFormat, pur SSR stable

## Mobile
- Grid `sm:grid-cols-2` pour le bloc stats
- Layout vertical sous 640px, aligné à la pile précédente (touch targets 44px respectés)

## Test plan
- [ ] CI verte (typecheck + lint + build)
- [ ] Preview Vercel accessible
- [ ] Compte avec data : streak + historique visibles, dernière perf complète
- [ ] Compte vide : empty state affiché, pas de bloc inutile
- [ ] Mobile 390×844 : aucun overflow horizontal
- [ ] FR / NL / EN : pluralization correcte (1 jour / 2 jours / 0 jour)
- [ ] A11y : heading structure (sr-only h2), aria-label profile link
- [ ] Sourcery clean