### PR TITLE
feat(history): page historique des séances avec filtres + pagination

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -245,12 +245,24 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
 
       {/* Dernières séances */}
       <section className="mb-10 border-2 border-foreground p-6">
-        <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
-          {t('stats.recentWorkouts.label')}
-        </p>
-        <h2 className="mt-3 mb-6 font-display text-2xl leading-snug text-foreground">
-          {t('stats.recentWorkouts.heading')}
-        </h2>
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+              {t('stats.recentWorkouts.label')}
+            </p>
+            <h2 className="mt-3 font-display text-2xl leading-snug text-foreground">
+              {t('stats.recentWorkouts.heading')}
+            </h2>
+          </div>
+          {stats.recentWorkouts.length > 0 && (
+            <Link
+              href={`/${typedLocale}/history`}
+              className="mt-1 shrink-0 inline-flex min-h-11 items-center font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+            >
+              {t('stats.recentWorkouts.viewAll')} →
+            </Link>
+          )}
+        </div>
 
         {stats.recentWorkouts.length === 0 ? (
           <p className="text-base text-muted-foreground">

--- a/src/app/[locale]/history/page.tsx
+++ b/src/app/[locale]/history/page.tsx
@@ -1,0 +1,266 @@
+import Link from 'next/link';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+import { requireUser } from '@/lib/auth';
+import {
+  formatDuration,
+  formatRelativeDate,
+} from '@/lib/dashboard/format';
+import {
+  getHistoryPage,
+  historyPeriodSchema,
+  historyTypeSchema,
+  type HistoryFilters,
+  type HistoryPeriod,
+  type HistoryType,
+} from '@/lib/history';
+
+interface HistoryPageProps {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{
+    period?: string;
+    type?: string;
+    cursor?: string;
+  }>;
+}
+
+export const metadata = {
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Historique complet des séances — filtrable (période + type) et paginé
+ * par curseur (end_time desc).
+ *
+ * Full-SSR : filtres et pagination passent par des liens (`?period=…`).
+ * Aucun JS nécessaire — accessibilité maximale, navigation fluide et
+ * partageable via URL.
+ */
+export default async function HistoryPage({
+  params,
+  searchParams,
+}: HistoryPageProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+
+  const user = await requireUser(typedLocale);
+  const sp = await searchParams;
+
+  // --- Filtres (parsing défensif) ---
+  const periodParse = historyPeriodSchema.safeParse(sp.period);
+  const typeParse = historyTypeSchema.safeParse(sp.type);
+  const period: HistoryPeriod = periodParse.success ? periodParse.data : '30d';
+  const type: HistoryType = typeParse.success ? typeParse.data : 'all';
+  // Le cursor vient toujours de NOUS (on le régénère à chaque page), donc si
+  // un utilisateur modifie la query string et entre un truc invalide, on
+  // remet `null` plutôt que de planter.
+  const cursor =
+    sp.cursor && /^\d{4}-\d{2}-\d{2}T/.test(sp.cursor) ? sp.cursor : null;
+
+  const filters: HistoryFilters = { period, type, cursor };
+  const pageData = await getHistoryPage(user.id, filters);
+
+  const t = await getTranslations({
+    locale: typedLocale,
+    namespace: 'history',
+  });
+
+  const buildHref = (override: Partial<{ period: HistoryPeriod; type: HistoryType; cursor: string | null }>) => {
+    const nextPeriod = override.period ?? period;
+    const nextType = override.type ?? type;
+    // Cursor: override explicit (incl. `null` pour reset)
+    const nextCursor =
+      'cursor' in override ? override.cursor : null;
+    const usp = new URLSearchParams();
+    if (nextPeriod !== '30d') usp.set('period', nextPeriod);
+    if (nextType !== 'all') usp.set('type', nextType);
+    if (nextCursor) usp.set('cursor', nextCursor);
+    const qs = usp.toString();
+    return `/${typedLocale}/history${qs ? `?${qs}` : ''}`;
+  };
+
+  const periodOptions: HistoryPeriod[] = ['7d', '30d', '90d', 'all'];
+  const typeOptions: HistoryType[] = ['all', 'strength', 'cardio'];
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-16">
+      <header className="mb-10">
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          {t('eyebrow')}
+        </p>
+        <h1 className="mt-3 font-display text-4xl leading-tight text-foreground sm:text-5xl">
+          {t('title')}
+        </h1>
+        <p className="mt-3 text-base text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      {/* Filtres */}
+      <section
+        aria-labelledby="filters-heading"
+        className="mb-8 border-2 border-foreground p-6"
+      >
+        <h2
+          id="filters-heading"
+          className="font-mono text-xs uppercase tracking-widest text-muted-foreground"
+        >
+          {t('filters.label')}
+        </h2>
+
+        <div className="mt-5 grid gap-6 sm:grid-cols-2">
+          <FilterGroup label={t('filters.period.label')}>
+            {periodOptions.map((p) => (
+              <FilterPill
+                key={p}
+                active={p === period}
+                href={buildHref({ period: p, cursor: null })}
+                label={t(`filters.period.${p}`)}
+              />
+            ))}
+          </FilterGroup>
+
+          <FilterGroup label={t('filters.type.label')}>
+            {typeOptions.map((ty) => (
+              <FilterPill
+                key={ty}
+                active={ty === type}
+                href={buildHref({ type: ty, cursor: null })}
+                label={t(`filters.type.${ty}`)}
+              />
+            ))}
+          </FilterGroup>
+        </div>
+
+        {(period !== '30d' || type !== 'all' || cursor) && (
+          <Link
+            href={`/${typedLocale}/history`}
+            className="mt-6 inline-flex min-h-11 items-center font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+          >
+            ← {t('filters.reset')}
+          </Link>
+        )}
+      </section>
+
+      {/* Comptage */}
+      <p
+        className="mb-4 font-mono text-xs uppercase tracking-widest text-muted-foreground"
+        aria-live="polite"
+      >
+        {t('totalCount', { count: pageData.totalCount })}
+      </p>
+
+      {/* Liste / Empty */}
+      {pageData.items.length === 0 ? (
+        <section className="border-2 border-foreground p-8 text-center">
+          <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('empty.label')}
+          </p>
+          <p className="mt-3 font-display text-2xl leading-snug text-foreground">
+            {t('empty.body')}
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {t('empty.subtext')}
+          </p>
+        </section>
+      ) : (
+        <section className="border-2 border-foreground p-6">
+          <ul className="divide-y divide-border">
+            {pageData.items.map((w) => (
+              <li
+                key={w.id}
+                className="flex flex-col gap-1 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+              >
+                <div className="min-w-0">
+                  <p className="font-display text-lg leading-snug text-foreground break-words">
+                    {w.name}
+                  </p>
+                  {w.type && (
+                    <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+                      {w.type}
+                    </p>
+                  )}
+                </div>
+                <div className="flex flex-col gap-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground sm:text-right">
+                  <span>{formatRelativeDate(w.endTime, typedLocale)}</span>
+                  {w.durationSeconds !== null && w.durationSeconds > 0 && (
+                    <span>
+                      {formatDuration(w.durationSeconds, typedLocale)}
+                    </span>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-6 flex items-center justify-between gap-4">
+            {pageData.nextCursor ? (
+              <Link
+                href={buildHref({ cursor: pageData.nextCursor })}
+                className="inline-flex min-h-11 items-center border-2 border-foreground px-5 font-mono text-xs uppercase tracking-widest text-foreground transition hover:bg-muted"
+              >
+                {t('loadMore')} →
+              </Link>
+            ) : (
+              <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+                {t('endOfList')}
+              </p>
+            )}
+          </div>
+        </section>
+      )}
+
+      <nav className="mt-10 font-mono text-xs uppercase tracking-widest">
+        <Link
+          href={`/${typedLocale}/dashboard`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          ← {t('back')}
+        </Link>
+      </nav>
+    </main>
+  );
+}
+
+function FilterGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="mb-2 font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </p>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </div>
+  );
+}
+
+function FilterPill({
+  active,
+  href,
+  label,
+}: {
+  active: boolean;
+  href: string;
+  label: string;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={active ? 'page' : undefined}
+      className={
+        active
+          ? 'inline-flex min-h-11 items-center border-2 border-foreground bg-foreground px-4 font-mono text-xs uppercase tracking-widest text-background'
+          : 'inline-flex min-h-11 items-center border-2 border-foreground px-4 font-mono text-xs uppercase tracking-widest text-foreground transition hover:bg-muted'
+      }
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1,6 +1,11 @@
 {
-  "brand": { "name": "IronTrack", "tagline": "Train heavier, live lighter." },
-  "common": { "scrollToTop": "Back to top" },
+  "brand": {
+    "name": "IronTrack",
+    "tagline": "Train heavier, live lighter."
+  },
+  "common": {
+    "scrollToTop": "Back to top"
+  },
   "nav": {
     "home": "Home",
     "workouts": "Sessions",
@@ -21,10 +26,22 @@
     },
     "lede": "A fitness app built like a workshop notebook: precise, editorial, brutalist. No confetti. No jargon. Just your body, your numbers, your progress.",
     "meta": {
-      "stack": { "label": "Stack", "value": "Next 16" },
-      "backend": { "label": "Backend", "value": "Supabase" },
-      "budget": { "label": "Budget", "value": "€0" },
-      "target": { "label": "Target", "value": "Hevy · Strava · Whoop" }
+      "stack": {
+        "label": "Stack",
+        "value": "Next 16"
+      },
+      "backend": {
+        "label": "Backend",
+        "value": "Supabase"
+      },
+      "budget": {
+        "label": "Budget",
+        "value": "€0"
+      },
+      "target": {
+        "label": "Target",
+        "value": "Hevy · Strava · Whoop"
+      }
     },
     "build": {
       "heading": "We're building",
@@ -200,9 +217,11 @@
       "recentWorkouts": {
         "label": "HISTORY",
         "heading": "Your latest sessions.",
-        "empty": "No completed sessions yet."
+        "empty": "No completed sessions yet.",
+        "viewAll": "View full history"
       }
-    }
+    },
+    "historyLink": "View full history"
   },
   "profile": {
     "metaTitle": "My profile",
@@ -378,5 +397,36 @@
         "body": "IronTrack is not medical advice. Consult a healthcare professional before any intensive programme. The service is provided \"as is\" during the alpha phase."
       }
     }
+  },
+  "history": {
+    "eyebrow": "HISTORY",
+    "title": "Your sessions.",
+    "subtitle": "All your completed workouts, filterable.",
+    "back": "Back to dashboard",
+    "empty": {
+      "label": "NO SESSIONS",
+      "body": "Nothing to show for these filters.",
+      "subtext": "Change the period or type, or start your first workout."
+    },
+    "totalCount": "{count, plural, =0 {no workouts} one {# workout} other {# workouts}}",
+    "filters": {
+      "label": "FILTERS",
+      "period": {
+        "label": "Period",
+        "7d": "7 days",
+        "30d": "30 days",
+        "90d": "90 days",
+        "all": "All"
+      },
+      "type": {
+        "label": "Type",
+        "all": "All",
+        "strength": "Strength",
+        "cardio": "Cardio"
+      },
+      "reset": "Reset"
+    },
+    "loadMore": "Load more",
+    "endOfList": "End of history."
   }
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -217,9 +217,11 @@
       "recentWorkouts": {
         "label": "HISTORIQUE",
         "heading": "Tes dernières séances.",
-        "empty": "Aucune séance complétée pour l'instant."
+        "empty": "Aucune séance complétée pour l'instant.",
+        "viewAll": "Voir tout l'historique"
       }
-    }
+    },
+    "historyLink": "Voir tout l'historique"
   },
   "profile": {
     "metaTitle": "Mon profil",
@@ -395,5 +397,36 @@
         "body": "IronTrack n'est pas un avis médical. Consulte un professionnel de santé avant tout programme intensif. Le service est fourni \"en l'état\" pendant la phase alpha."
       }
     }
+  },
+  "history": {
+    "eyebrow": "HISTORIQUE",
+    "title": "Tes séances.",
+    "subtitle": "Toutes tes séances complétées, filtrables.",
+    "back": "Retour au dashboard",
+    "empty": {
+      "label": "AUCUNE SÉANCE",
+      "body": "Rien à afficher pour ces filtres.",
+      "subtext": "Change la période ou le type, ou lance ta première séance."
+    },
+    "totalCount": "{count, plural, =0 {aucune séance} one {# séance} other {# séances}}",
+    "filters": {
+      "label": "FILTRES",
+      "period": {
+        "label": "Période",
+        "7d": "7 jours",
+        "30d": "30 jours",
+        "90d": "90 jours",
+        "all": "Tout"
+      },
+      "type": {
+        "label": "Type",
+        "all": "Tous",
+        "strength": "Musculation",
+        "cardio": "Cardio"
+      },
+      "reset": "Réinitialiser"
+    },
+    "loadMore": "Charger plus",
+    "endOfList": "Fin de l'historique."
   }
 }

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -217,9 +217,11 @@
       "recentWorkouts": {
         "label": "HISTORIEK",
         "heading": "Je laatste sessies.",
-        "empty": "Nog geen voltooide sessies."
+        "empty": "Nog geen voltooide sessies.",
+        "viewAll": "Volledige geschiedenis"
       }
-    }
+    },
+    "historyLink": "Volledige geschiedenis"
   },
   "profile": {
     "metaTitle": "Mijn profiel",
@@ -395,5 +397,36 @@
         "body": "IronTrack is geen medisch advies. Raadpleeg een zorgverlener vóór elk intensief programma. De dienst wordt \"as is\" geleverd tijdens de alpha."
       }
     }
+  },
+  "history": {
+    "eyebrow": "GESCHIEDENIS",
+    "title": "Jouw sessies.",
+    "subtitle": "Al je voltooide sessies, filterbaar.",
+    "back": "Terug naar dashboard",
+    "empty": {
+      "label": "GEEN SESSIES",
+      "body": "Niets te tonen voor deze filters.",
+      "subtext": "Pas de periode of het type aan, of start je eerste sessie."
+    },
+    "totalCount": "{count, plural, =0 {geen sessies} one {# sessie} other {# sessies}}",
+    "filters": {
+      "label": "FILTERS",
+      "period": {
+        "label": "Periode",
+        "7d": "7 dagen",
+        "30d": "30 dagen",
+        "90d": "90 dagen",
+        "all": "Alles"
+      },
+      "type": {
+        "label": "Type",
+        "all": "Alle",
+        "strength": "Krachttraining",
+        "cardio": "Cardio"
+      },
+      "reset": "Resetten"
+    },
+    "loadMore": "Meer laden",
+    "endOfList": "Einde van de geschiedenis."
   }
 }

--- a/src/lib/history/index.ts
+++ b/src/lib/history/index.ts
@@ -1,0 +1,120 @@
+import { createServerClient } from '@/lib/supabase';
+
+import {
+  HISTORY_PAGE_SIZE,
+  TYPE_DB_MAP,
+  historyPageSchema,
+  type HistoryFilters,
+  type HistoryItem,
+  type HistoryPage,
+} from './schema';
+
+/**
+ * Mêmes statuts "terminés" que le dashboard — contrainte legacy FR.
+ * @see src/lib/dashboard/index.ts
+ */
+const COMPLETED_STATUSES = ['Terminé', 'Réalisé'] as const;
+
+/**
+ * Retourne une page d'historique des séances de l'utilisateur courant.
+ *
+ * - Pagination cursor sur `end_time DESC` : stable même si de nouvelles
+ *   séances sont insérées entre deux pages (pas de "jumping rows").
+ * - RLS Supabase + `.eq('user_id')` en defense-in-depth.
+ * - Erreur → page vide plutôt que crash (la page parente affichera l'état
+ *   vide).
+ */
+export async function getHistoryPage(
+  userId: string,
+  filters: HistoryFilters,
+): Promise<HistoryPage> {
+  const supabase = await createServerClient();
+
+  // --- Période ---
+  const periodStart = periodStartISO(filters.period);
+
+  // --- Query ---
+  let query = supabase
+    .from('workouts')
+    .select('id, name, end_time, duration, type, status', { count: 'exact' })
+    .eq('user_id', userId)
+    .in('status', COMPLETED_STATUSES)
+    .not('end_time', 'is', null)
+    .order('end_time', { ascending: false })
+    // +1 pour détecter "y a-t-il une page suivante ?" sans second round-trip
+    .limit(HISTORY_PAGE_SIZE + 1);
+
+  if (periodStart) {
+    query = query.gte('end_time', periodStart);
+  }
+  if (filters.type !== 'all') {
+    query = query.in('type', TYPE_DB_MAP[filters.type]);
+  }
+  if (filters.cursor) {
+    // Strictly less than : pas de doublon entre pages.
+    query = query.lt('end_time', filters.cursor);
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    console.error('[history] query failed:', error.message);
+    return { items: [], nextCursor: null, totalCount: 0 };
+  }
+
+  const rawRows = data ?? [];
+  const hasMore = rawRows.length > HISTORY_PAGE_SIZE;
+  const trimmed = hasMore ? rawRows.slice(0, HISTORY_PAGE_SIZE) : rawRows;
+
+  const items: HistoryItem[] = trimmed
+    // Guard défensif : on a `.not('end_time', 'is', null)`, mais on reste prudent.
+    .filter((w): w is typeof w & { end_time: string } => w.end_time !== null)
+    .map((w) => ({
+      id: w.id,
+      name: w.name,
+      endTime: w.end_time,
+      durationSeconds: w.duration,
+      type: w.type,
+    }));
+
+  const nextCursor =
+    hasMore && items.length > 0
+      ? (items[items.length - 1]?.endTime ?? null)
+      : null;
+
+  const parsed = historyPageSchema.safeParse({
+    items,
+    nextCursor,
+    totalCount: count ?? items.length,
+  });
+
+  if (!parsed.success) {
+    console.error(
+      '[history] schema validation failed:',
+      parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+    );
+    return { items: [], nextCursor: null, totalCount: 0 };
+  }
+
+  return parsed.data;
+}
+
+function periodStartISO(period: HistoryFilters['period']): string | null {
+  if (period === 'all') return null;
+  const days = period === '7d' ? 7 : period === '30d' ? 30 : 90;
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+export type {
+  HistoryFilters,
+  HistoryItem,
+  HistoryPage,
+  HistoryPeriod,
+  HistoryType,
+} from './schema';
+export {
+  HISTORY_PAGE_SIZE,
+  historyFiltersSchema,
+  historyPeriodSchema,
+  historyTypeSchema,
+} from './schema';

--- a/src/lib/history/schema.ts
+++ b/src/lib/history/schema.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+/**
+ * Schémas Zod pour la page d'historique des séances.
+ *
+ * Comme pour le dashboard, on valide en sortie de Supabase pour se protéger
+ * des dérives de schéma DB et des valeurs inattendues côté runtime.
+ */
+
+export const HISTORY_PAGE_SIZE = 20;
+
+export const historyPeriodSchema = z.enum(['7d', '30d', '90d', 'all']);
+export type HistoryPeriod = z.infer<typeof historyPeriodSchema>;
+
+export const historyTypeSchema = z.enum(['all', 'strength', 'cardio']);
+export type HistoryType = z.infer<typeof historyTypeSchema>;
+
+/**
+ * Mapping filtre UI -> valeurs legacy stockées en base.
+ * La contrainte `workouts_type_check` n'accepte que
+ * 'Musculation' | 'Cardio' | 'Étirement' | 'Repos'.
+ */
+export const TYPE_DB_MAP: Record<Exclude<HistoryType, 'all'>, string[]> = {
+  strength: ['Musculation'],
+  cardio: ['Cardio'],
+};
+
+export const historyFiltersSchema = z.object({
+  period: historyPeriodSchema.default('30d'),
+  type: historyTypeSchema.default('all'),
+  /** ISO date : fetch only workouts ended strictly before this cursor. */
+  cursor: z.string().datetime().nullable().default(null),
+});
+export type HistoryFilters = z.infer<typeof historyFiltersSchema>;
+
+export const historyItemSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  endTime: z.string().datetime(),
+  durationSeconds: z.number().int().nonnegative().nullable(),
+  type: z.string().nullable(),
+});
+export type HistoryItem = z.infer<typeof historyItemSchema>;
+
+export const historyPageSchema = z.object({
+  items: z.array(historyItemSchema).max(HISTORY_PAGE_SIZE),
+  /** Curseur vers la page suivante (ISO end_time du dernier item) ou null. */
+  nextCursor: z.string().datetime().nullable(),
+  /** Total estimé, renvoyé par Supabase via count: 'exact'. */
+  totalCount: z.number().int().nonnegative(),
+});
+export type HistoryPage = z.infer<typeof historyPageSchema>;


### PR DESCRIPTION
## Summary
- Nouvelle route `/[locale]/history` qui liste **toutes** les séances complétées (le dashboard n'en montre que 5)
- Filtres **URL-based** (period + type) → full SSR, zero JS, accessible, partageable
- Pagination **par curseur** sur `end_time DESC` (stable vs nouvelles insertions concurrentes)
- Lien "Voir tout →" ajouté dans le bloc "dernières séances" du dashboard
- i18n fr/nl/en avec pluralisation ICU sur le compteur

## Sécurité
- Lit via `createServerClient` (cookies user) : **RLS** Supabase + `.eq('user_id')` defense-in-depth
- Parsing défensif des query params via **Zod** (period/type/cursor) → fallback silencieux si utilisateur bidouille l'URL
- Validation défensive de la forme de sortie (Zod) → page vide plutôt que crash
- Statuts legacy FR ('Terminé'/'Réalisé') via constante partagée

## Accessibilité
- Pills filtres avec `aria-current="page"` pour la valeur active
- Compteur total avec `aria-live="polite"` (annoncé aux SR au changement de filtre)
- Touch targets ≥ 44px partout (min-h-11)
- `h1/h2` correctement hiérarchisés + `aria-labelledby` sur section filtres

## Test plan
- [ ] `/fr/history` charge sans filtre → liste 20 dernières (30j par défaut)
- [ ] Filtre period=7d → query `gte` end_time = now-7d
- [ ] Filtre type=strength → `in ('Musculation')`
- [ ] Clic "Charger plus" → cursor dans URL, page suivante sans doublons
- [ ] Reset filtres → URL vierge `/fr/history`
- [ ] Compteur total s'actualise au changement de filtre
- [ ] Empty state (changer user test, ou filtre 7d sur user sans data récente)
- [ ] Dashboard: le lien "Voir tout →" n'apparaît que si recentWorkouts.length > 0
- [ ] Mobile 390px: filtres empilent proprement (sm:grid-cols-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)