### PR TITLE
feat(workouts): page détail /workouts/[id]

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -271,28 +271,30 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
         ) : (
           <ul className="divide-y divide-border">
             {stats.recentWorkouts.map((w) => (
-              <li
-                key={w.id}
-                className="flex flex-col gap-1 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
-              >
-                <div className="min-w-0">
-                  <p className="font-display text-lg leading-snug text-foreground break-words">
-                    {w.name}
-                  </p>
-                  {w.type && (
-                    <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground">
-                      {w.type}
+              <li key={w.id}>
+                <Link
+                  href={`/${typedLocale}/workouts/${w.id}`}
+                  className="-mx-3 flex flex-col gap-1 rounded-sm px-3 py-4 transition hover:bg-muted focus-visible:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+                >
+                  <div className="min-w-0">
+                    <p className="font-display text-lg leading-snug text-foreground break-words">
+                      {w.name}
                     </p>
-                  )}
-                </div>
-                <div className="flex flex-col gap-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground sm:text-right">
-                  <span>{formatRelativeDate(w.endTime, typedLocale)}</span>
-                  {w.durationSeconds !== null && w.durationSeconds > 0 && (
-                    <span>
-                      {formatDuration(w.durationSeconds, typedLocale)}
-                    </span>
-                  )}
-                </div>
+                    {w.type && (
+                      <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+                        {w.type}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground sm:text-right">
+                    <span>{formatRelativeDate(w.endTime, typedLocale)}</span>
+                    {w.durationSeconds !== null && w.durationSeconds > 0 && (
+                      <span>
+                        {formatDuration(w.durationSeconds, typedLocale)}
+                      </span>
+                    )}
+                  </div>
+                </Link>
               </li>
             ))}
           </ul>

--- a/src/app/[locale]/history/page.tsx
+++ b/src/app/[locale]/history/page.tsx
@@ -169,28 +169,30 @@ export default async function HistoryPage({
         <section className="border-2 border-foreground p-6">
           <ul className="divide-y divide-border">
             {pageData.items.map((w) => (
-              <li
-                key={w.id}
-                className="flex flex-col gap-1 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6"
-              >
-                <div className="min-w-0">
-                  <p className="font-display text-lg leading-snug text-foreground break-words">
-                    {w.name}
-                  </p>
-                  {w.type && (
-                    <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground">
-                      {w.type}
+              <li key={w.id}>
+                <Link
+                  href={`/${typedLocale}/workouts/${w.id}`}
+                  className="-mx-3 flex flex-col gap-1 rounded-sm px-3 py-4 transition hover:bg-muted focus-visible:bg-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground sm:flex-row sm:items-center sm:justify-between sm:gap-6"
+                >
+                  <div className="min-w-0">
+                    <p className="font-display text-lg leading-snug text-foreground break-words">
+                      {w.name}
                     </p>
-                  )}
-                </div>
-                <div className="flex flex-col gap-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground sm:text-right">
-                  <span>{formatRelativeDate(w.endTime, typedLocale)}</span>
-                  {w.durationSeconds !== null && w.durationSeconds > 0 && (
-                    <span>
-                      {formatDuration(w.durationSeconds, typedLocale)}
-                    </span>
-                  )}
-                </div>
+                    {w.type && (
+                      <p className="mt-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+                        {w.type}
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex flex-col gap-0.5 font-mono text-xs uppercase tracking-widest text-muted-foreground sm:text-right">
+                    <span>{formatRelativeDate(w.endTime, typedLocale)}</span>
+                    {w.durationSeconds !== null && w.durationSeconds > 0 && (
+                      <span>
+                        {formatDuration(w.durationSeconds, typedLocale)}
+                      </span>
+                    )}
+                  </div>
+                </Link>
               </li>
             ))}
           </ul>

--- a/src/app/[locale]/workouts/[id]/page.tsx
+++ b/src/app/[locale]/workouts/[id]/page.tsx
@@ -42,6 +42,10 @@ export default async function WorkoutDetailPage({
     : 'fr';
   setRequestLocale(typedLocale);
 
+  // Auth AVANT tout parsing — un anonyme ne doit pas pouvoir sonder
+  // l'espace des URLs (même pour se voir renvoyer un 404).
+  const user = await requireUser(typedLocale);
+
   // Parsing strict : rejette "abc", "1.5", "1e10", négatifs.
   const workoutId = Number.parseInt(idParam, 10);
   if (
@@ -52,7 +56,6 @@ export default async function WorkoutDetailPage({
     notFound();
   }
 
-  const user = await requireUser(typedLocale);
   const detail = await getWorkoutDetail(user.id, workoutId);
   if (!detail) notFound();
 

--- a/src/app/[locale]/workouts/[id]/page.tsx
+++ b/src/app/[locale]/workouts/[id]/page.tsx
@@ -1,0 +1,270 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+import { requireUser } from '@/lib/auth';
+import {
+  formatDistance,
+  formatDuration,
+  formatRelativeDate,
+} from '@/lib/dashboard/format';
+import {
+  getWorkoutDetail,
+  type PerformanceLogEntry,
+  type WorkoutExerciseGroup,
+} from '@/lib/workouts';
+
+interface WorkoutDetailPageProps {
+  params: Promise<{ locale: string; id: string }>;
+}
+
+export const metadata = {
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Détail d'une séance — full SSR, lecture seule.
+ *
+ * Sécurité :
+ *  - `requireUser()` → redirige vers /login si non connecté
+ *  - `getWorkoutDetail()` filtre par `user_id` + RLS : un autre user renverra
+ *    `null` → `notFound()` localisé (pas d'exfiltration : même réponse qu'une
+ *    séance inexistante).
+ *  - `id` parsé avec parseInt + isFinite (rejette NaN, Infinity, flottants).
+ */
+export default async function WorkoutDetailPage({
+  params,
+}: WorkoutDetailPageProps) {
+  const { locale, id: idParam } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+
+  // Parsing strict : rejette "abc", "1.5", "1e10", négatifs.
+  const workoutId = Number.parseInt(idParam, 10);
+  if (
+    !Number.isFinite(workoutId) ||
+    workoutId <= 0 ||
+    String(workoutId) !== idParam
+  ) {
+    notFound();
+  }
+
+  const user = await requireUser(typedLocale);
+  const detail = await getWorkoutDetail(user.id, workoutId);
+  if (!detail) notFound();
+
+  const t = await getTranslations({
+    locale: typedLocale,
+    namespace: 'workoutDetail',
+  });
+
+  const sessionDate =
+    detail.endTime ?? detail.scheduledDate ?? detail.createdAt;
+
+  const totalSets = detail.exercises.reduce(
+    (acc, g) => acc + g.logs.length,
+    0,
+  );
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-16">
+      {/* Header */}
+      <header className="mb-10">
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          {t('eyebrow')}
+        </p>
+        <h1 className="mt-3 font-display text-4xl leading-tight text-foreground break-words sm:text-5xl">
+          {detail.name}
+        </h1>
+        <div className="mt-4 flex flex-wrap gap-4 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {detail.type && <span>{detail.type}</span>}
+          {detail.status && <span>· {detail.status}</span>}
+          <span>· {formatRelativeDate(sessionDate, typedLocale)}</span>
+        </div>
+      </header>
+
+      {/* Métadonnées de séance */}
+      <section className="mb-10 grid gap-4 border-2 border-foreground p-6 sm:grid-cols-3">
+        <StatTile
+          label={t('stats.duration')}
+          value={formatDuration(detail.durationSeconds, typedLocale)}
+        />
+        <StatTile
+          label={t('stats.exercises')}
+          value={String(detail.exercises.length)}
+        />
+        <StatTile label={t('stats.sets')} value={String(totalSets)} />
+      </section>
+
+      {/* Notes séance */}
+      {detail.notes && (
+        <section className="mb-10 border-2 border-foreground p-6">
+          <h2 className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('notes.label')}
+          </h2>
+          <p className="mt-3 whitespace-pre-wrap text-base text-foreground">
+            {detail.notes}
+          </p>
+        </section>
+      )}
+
+      {/* Exercices */}
+      {detail.exercises.length === 0 ? (
+        <section className="border-2 border-foreground p-8 text-center">
+          <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('empty.label')}
+          </p>
+          <p className="mt-3 font-display text-2xl leading-snug text-foreground">
+            {t('empty.body')}
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {t('empty.subtext')}
+          </p>
+        </section>
+      ) : (
+        <section aria-labelledby="exercises-heading" className="space-y-6">
+          <h2
+            id="exercises-heading"
+            className="font-mono text-xs uppercase tracking-widest text-muted-foreground"
+          >
+            {t('exercises.heading')}
+          </h2>
+          {detail.exercises.map((group) => (
+            <ExerciseBlock
+              key={group.exerciseId}
+              group={group}
+              locale={typedLocale}
+              tSet={t('set.label')}
+            />
+          ))}
+        </section>
+      )}
+
+      <nav className="mt-12 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
+        <Link
+          href={`/${typedLocale}/history`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          ← {t('back.history')}
+        </Link>
+        <Link
+          href={`/${typedLocale}/dashboard`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          {t('back.dashboard')} →
+        </Link>
+      </nav>
+    </main>
+  );
+}
+
+function StatTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </p>
+      <p className="mt-1 font-display text-2xl leading-snug text-foreground">
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function ExerciseBlock({
+  group,
+  locale,
+  tSet,
+}: {
+  group: WorkoutExerciseGroup;
+  locale: Locale;
+  tSet: string;
+}) {
+  return (
+    <article className="border-2 border-foreground p-6">
+      <header className="mb-4">
+        <h3 className="font-display text-xl leading-snug text-foreground break-words">
+          {group.exerciseName}
+        </h3>
+        <p className="mt-1 font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+          {group.logs.length}&nbsp;×&nbsp;{tSet}
+        </p>
+      </header>
+      <ul className="divide-y divide-border">
+        {group.logs.map((log, idx) => (
+          <li
+            key={log.id}
+            className="flex flex-wrap items-baseline gap-x-4 gap-y-1 py-3"
+          >
+            <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+              {tSet} {log.setNumber ?? idx + 1}
+            </span>
+            <SetMetrics log={log} locale={locale} />
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}
+
+/**
+ * Affiche les métriques pertinentes d'un set — skip les null/0 pour garder
+ * un rendu dense et lisible. Charte brutaliste : typo mono, pas d'icônes.
+ */
+function SetMetrics({
+  log,
+  locale,
+}: {
+  log: PerformanceLogEntry;
+  locale: Locale;
+}) {
+  const metrics: string[] = [];
+
+  if (log.reps !== null && log.reps > 0) {
+    metrics.push(`${log.reps} reps`);
+  }
+  if (log.weightKg !== null && log.weightKg > 0) {
+    metrics.push(`${log.weightKg} kg`);
+  }
+
+  const distance = formatDistance(log.distance, log.distanceUnit, locale);
+  if (distance) metrics.push(distance);
+
+  if (log.durationSeconds !== null && log.durationSeconds > 0) {
+    metrics.push(formatDuration(log.durationSeconds, locale));
+  }
+  if (log.watts !== null && log.watts > 0) metrics.push(`${log.watts} W`);
+  if (log.strokeRate !== null && log.strokeRate > 0) {
+    metrics.push(`${log.strokeRate} SPM`);
+  }
+  if (log.cadence !== null && log.cadence > 0) {
+    metrics.push(`${log.cadence} RPM`);
+  }
+  if (log.resistance !== null && log.resistance > 0) {
+    metrics.push(`R${log.resistance}`);
+  }
+  if (log.incline !== null && log.incline > 0) {
+    metrics.push(`${log.incline}%`);
+  }
+  if (log.heartRate !== null && log.heartRate > 0) {
+    metrics.push(`${log.heartRate} bpm`);
+  }
+  if (log.rpe !== null && log.rpe > 0) metrics.push(`RPE ${log.rpe}`);
+
+  if (metrics.length === 0) {
+    return (
+      <span className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+        —
+      </span>
+    );
+  }
+
+  return (
+    <span className="font-mono text-sm tabular-nums text-foreground">
+      {metrics.join(' · ')}
+    </span>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -429,6 +429,32 @@
     "loadMore": "Load more",
     "endOfList": "End of history."
   },
+  "workoutDetail": {
+    "eyebrow": "WORKOUT",
+    "stats": {
+      "duration": "Duration",
+      "exercises": "Exercises",
+      "sets": "Sets"
+    },
+    "notes": {
+      "label": "NOTES"
+    },
+    "exercises": {
+      "heading": "EXERCISES"
+    },
+    "set": {
+      "label": "Set"
+    },
+    "empty": {
+      "label": "NO EXERCISE",
+      "body": "Nothing to show.",
+      "subtext": "This workout has no logged set yet."
+    },
+    "back": {
+      "history": "Back to history",
+      "dashboard": "Dashboard"
+    }
+  },
   "notFound": {
     "eyebrow": "ERROR 404",
     "title": "Nothing here.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -429,6 +429,32 @@
     "loadMore": "Charger plus",
     "endOfList": "Fin de l'historique."
   },
+  "workoutDetail": {
+    "eyebrow": "SÉANCE",
+    "stats": {
+      "duration": "Durée",
+      "exercises": "Exercices",
+      "sets": "Sets"
+    },
+    "notes": {
+      "label": "NOTES"
+    },
+    "exercises": {
+      "heading": "EXERCICES"
+    },
+    "set": {
+      "label": "Set"
+    },
+    "empty": {
+      "label": "AUCUN EXERCICE",
+      "body": "Rien à afficher.",
+      "subtext": "Cette séance ne contient pas encore de set enregistré."
+    },
+    "back": {
+      "history": "Retour à l'historique",
+      "dashboard": "Tableau de bord"
+    }
+  },
   "notFound": {
     "eyebrow": "ERREUR 404",
     "title": "Rien ici.",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -429,6 +429,32 @@
     "loadMore": "Meer laden",
     "endOfList": "Einde van de geschiedenis."
   },
+  "workoutDetail": {
+    "eyebrow": "SESSIE",
+    "stats": {
+      "duration": "Duur",
+      "exercises": "Oefeningen",
+      "sets": "Sets"
+    },
+    "notes": {
+      "label": "NOTITIES"
+    },
+    "exercises": {
+      "heading": "OEFENINGEN"
+    },
+    "set": {
+      "label": "Set"
+    },
+    "empty": {
+      "label": "GEEN OEFENING",
+      "body": "Niets te tonen.",
+      "subtext": "Deze sessie bevat nog geen geregistreerde set."
+    },
+    "back": {
+      "history": "Terug naar geschiedenis",
+      "dashboard": "Dashboard"
+    }
+  },
   "notFound": {
     "eyebrow": "FOUT 404",
     "title": "Niets hier.",

--- a/src/lib/workouts/index.ts
+++ b/src/lib/workouts/index.ts
@@ -1,0 +1,143 @@
+import { createServerClient } from '@/lib/supabase';
+
+import {
+  workoutDetailSchema,
+  type PerformanceLogEntry,
+  type WorkoutDetail,
+  type WorkoutExerciseGroup,
+} from './schema';
+
+/**
+ * Retourne le détail d'une séance de l'utilisateur courant, ou `null` si :
+ *   - la séance n'existe pas
+ *   - elle appartient à un autre user (RLS rejette, `.eq('user_id')` en plus)
+ *   - la validation défensive échoue
+ *
+ * Stratégie : 2 queries parallèles (metadata workout + logs + exercise names
+ * via embed), puis groupement par `exercise_id` côté Node pour garder un SQL
+ * simple et lisible.
+ */
+export async function getWorkoutDetail(
+  userId: string,
+  workoutId: number,
+): Promise<WorkoutDetail | null> {
+  const supabase = await createServerClient();
+
+  const [workoutRes, logsRes] = await Promise.all([
+    supabase
+      .from('workouts')
+      .select(
+        'id, name, type, status, scheduled_date, start_time, end_time, duration, notes, created_at',
+      )
+      .eq('id', workoutId)
+      .eq('user_id', userId)
+      .maybeSingle(),
+
+    supabase
+      .from('performance_logs')
+      .select(
+        `id, exercise_id, set_number, reps, sets, weight, rpe, rest_seconds, notes,
+         distance, distance_unit, duration, heart_rate, heart_rate_avg, heart_rate_max,
+         watts, stroke_rate, cadence, resistance, incline, performed_at,
+         exercise:exercises(id, name)`,
+      )
+      .eq('workout_id', workoutId)
+      .eq('user_id', userId)
+      .order('performed_at', { ascending: true })
+      .order('set_number', { ascending: true, nullsFirst: true }),
+  ]);
+
+  if (workoutRes.error) {
+    console.error('[workouts] query failed:', workoutRes.error.message);
+    return null;
+  }
+  if (!workoutRes.data) return null;
+
+  if (logsRes.error) {
+    console.error('[workouts] logs query failed:', logsRes.error.message);
+    // On continue avec logs vides plutôt que d'échouer complètement.
+  }
+
+  // --- Groupement par exercice ---
+  const groupsMap = new Map<number, WorkoutExerciseGroup>();
+
+  for (const row of logsRes.data ?? []) {
+    // Supabase renvoie `exercise` comme objet OU tableau selon la version du
+    // client — on normalise.
+    const exerciseRel = row.exercise as
+      | { id: number; name: string }
+      | { id: number; name: string }[]
+      | null;
+    const exercise = Array.isArray(exerciseRel) ? exerciseRel[0] : exerciseRel;
+
+    const exerciseId = exercise?.id ?? row.exercise_id;
+    if (exerciseId == null) continue;
+
+    const exerciseName = exercise?.name ?? 'Exercise';
+
+    const entry: PerformanceLogEntry = {
+      id: row.id,
+      setNumber: row.set_number,
+      reps: row.reps,
+      sets: row.sets,
+      weightKg: row.weight,
+      rpe: row.rpe,
+      restSeconds: row.rest_seconds,
+      notes: row.notes,
+      distance: row.distance,
+      distanceUnit: row.distance_unit,
+      durationSeconds: row.duration,
+      heartRate: row.heart_rate,
+      heartRateAvg: row.heart_rate_avg,
+      heartRateMax: row.heart_rate_max,
+      watts: row.watts,
+      strokeRate: row.stroke_rate,
+      cadence: row.cadence,
+      resistance: row.resistance,
+      incline: row.incline,
+      performedAt: row.performed_at,
+    };
+
+    const group = groupsMap.get(exerciseId);
+    if (group) {
+      group.logs.push(entry);
+    } else {
+      groupsMap.set(exerciseId, {
+        exerciseId,
+        exerciseName,
+        logs: [entry],
+      });
+    }
+  }
+
+  const w = workoutRes.data;
+  const parsed = workoutDetailSchema.safeParse({
+    id: w.id,
+    name: w.name,
+    type: w.type,
+    status: w.status,
+    scheduledDate: w.scheduled_date,
+    startTime: w.start_time,
+    endTime: w.end_time,
+    durationSeconds: w.duration,
+    notes: w.notes,
+    createdAt: w.created_at,
+    exercises: Array.from(groupsMap.values()),
+  });
+
+  if (!parsed.success) {
+    console.error(
+      '[workouts] schema validation failed:',
+      parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+    );
+    return null;
+  }
+
+  return parsed.data;
+}
+
+export type {
+  PerformanceLogEntry,
+  WorkoutDetail,
+  WorkoutExerciseGroup,
+} from './schema';

--- a/src/lib/workouts/schema.ts
+++ b/src/lib/workouts/schema.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+
+/**
+ * Schémas Zod pour la page de détail d'une séance.
+ *
+ * Comme pour dashboard / history : validation DÉFENSIVE en sortie de Supabase.
+ * Si la forme du retour dérive, on log et on retombe sur `null` plutôt que de
+ * faire planter la page.
+ */
+
+/**
+ * Une ligne `performance_logs` telle qu'on la sert au composant de détail.
+ * Les champs cardio avancés sont optionnels — ils n'existent que pour certains
+ * types d'exercice.
+ */
+export const performanceLogEntrySchema = z.object({
+  id: z.number(),
+  setNumber: z.number().int().nullable(),
+  reps: z.number().int().nullable(),
+  sets: z.number().int().nullable(),
+  weightKg: z.number().nullable(),
+  rpe: z.number().nullable(),
+  restSeconds: z.number().int().nullable(),
+  notes: z.string().nullable(),
+
+  // Cardio avancé
+  distance: z.number().nullable(),
+  distanceUnit: z.string().nullable(),
+  durationSeconds: z.number().int().nullable(),
+  heartRate: z.number().int().nullable(),
+  heartRateAvg: z.number().int().nullable(),
+  heartRateMax: z.number().int().nullable(),
+  watts: z.number().nullable(),
+  strokeRate: z.number().int().nullable(),
+  cadence: z.number().int().nullable(),
+  resistance: z.number().nullable(),
+  incline: z.number().nullable(),
+
+  performedAt: z.string().nullable(),
+});
+export type PerformanceLogEntry = z.infer<typeof performanceLogEntrySchema>;
+
+/**
+ * Un exercice d'une séance, avec TOUS ses logs groupés.
+ */
+export const workoutExerciseGroupSchema = z.object({
+  exerciseId: z.number(),
+  exerciseName: z.string(),
+  logs: z.array(performanceLogEntrySchema),
+});
+export type WorkoutExerciseGroup = z.infer<typeof workoutExerciseGroupSchema>;
+
+/**
+ * Détail complet d'une séance (métadonnées + exercices + logs).
+ */
+export const workoutDetailSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  type: z.string().nullable(),
+  status: z.string().nullable(),
+  scheduledDate: z.string().nullable(),
+  startTime: z.string().nullable(),
+  endTime: z.string().nullable(),
+  durationSeconds: z.number().int().nullable(),
+  notes: z.string().nullable(),
+  createdAt: z.string(),
+  exercises: z.array(workoutExerciseGroupSchema),
+});
+export type WorkoutDetail = z.infer<typeof workoutDetailSchema>;


### PR DESCRIPTION
## Summary
- Nouvelle page SSR `/[locale]/workouts/[id]` : affiche le détail d'une séance (metadata + exercices groupés + métriques cardio avancées)
- Fetcher `getWorkoutDetail()` + schémas Zod défensifs, RLS Supabase + `.eq('user_id')` en defense-in-depth
- 404 localisé si séance inconnue ou appartenant à un autre user (même réponse → pas d'exfiltration)
- Parsing strict de l'ID (rejette NaN / floats / négatifs)
- Dashboard + history : rows désormais full-row clickable (accessible focus-visible)
- i18n fr/nl/en (namespace `workoutDetail`)

## Sécurité
- `requireUser()` côté page → redirige /login si anonyme
- RLS Supabase active sur workouts + performance_logs
- Filtre redondant `.eq('user_id')` (defense-in-depth)
- Validation Zod en sortie : schéma DB dérive → log + null → notFound()
- Aucun `console.log`, pas de leak d'info dans les erreurs

## Test plan
- [ ] `/fr/workouts/42` → 404 (séance d'un autre user)
- [ ] `/fr/workouts/abc` → 404 (id invalide)
- [ ] `/fr/workouts/999999999` → 404 (inexistant)
- [ ] Anonyme sur `/fr/workouts/1` → redirect /login?next=…
- [ ] Dashboard row click → détail OK
- [ ] History row click + pagination click OK
- [ ] NL + EN OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)