### PR TITLE
feat(exercises): bibliothèque /exercises filtrable

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -303,6 +303,12 @@ export default async function DashboardPage({ params }: DashboardPageProps) {
 
       <nav className="mt-10 flex flex-wrap gap-6 font-mono text-xs uppercase tracking-widest">
         <Link
+          href={`/${typedLocale}/exercises`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          {t('exercisesLink')} →
+        </Link>
+        <Link
           href={`/${typedLocale}/profile`}
           className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
         >

--- a/src/app/[locale]/exercises/page.tsx
+++ b/src/app/[locale]/exercises/page.tsx
@@ -1,0 +1,346 @@
+import Link from 'next/link';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { LOCALES, type Locale } from '@/i18n/request';
+import { requireUser } from '@/lib/auth';
+import {
+  getExercises,
+  exerciseOwnershipSchema,
+  exerciseTypeSchema,
+  type ExerciseFilters,
+  type ExerciseOwnership,
+  type ExerciseTypeFilter,
+} from '@/lib/exercises';
+
+interface ExercisesPageProps {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{
+    type?: string;
+    muscle?: string;
+    ownership?: string;
+    q?: string;
+  }>;
+}
+
+export const metadata = {
+  robots: { index: false, follow: false },
+};
+
+/**
+ * Bibliothèque d'exercices — full SSR, filtrable via l'URL.
+ *
+ * Sécurité :
+ *  - `requireUser()` → redirige /login si anonyme
+ *  - RLS + `.or('user_id.eq.X,is_public.eq.true')` : on ne voit que ses
+ *    exercices + les publics
+ *  - Search échappe les wildcards LIKE côté fetcher
+ */
+export default async function ExercisesPage({
+  params,
+  searchParams,
+}: ExercisesPageProps) {
+  const { locale } = await params;
+  const typedLocale: Locale = (LOCALES as readonly string[]).includes(locale)
+    ? (locale as Locale)
+    : 'fr';
+  setRequestLocale(typedLocale);
+
+  const user = await requireUser(typedLocale);
+  const sp = await searchParams;
+
+  // --- Filtres (parsing défensif) ---
+  const typeParse = exerciseTypeSchema.safeParse(sp.type);
+  const type: ExerciseTypeFilter = typeParse.success ? typeParse.data : 'all';
+
+  const ownershipParse = exerciseOwnershipSchema.safeParse(sp.ownership);
+  const ownership: ExerciseOwnership = ownershipParse.success
+    ? ownershipParse.data
+    : 'all';
+
+  const muscle =
+    sp.muscle && sp.muscle.trim().length > 0 && sp.muscle.length <= 40
+      ? sp.muscle.trim()
+      : null;
+  const search =
+    sp.q && sp.q.trim().length > 0 && sp.q.length <= 80 ? sp.q.trim() : null;
+
+  const filters: ExerciseFilters = { type, muscle, ownership, search };
+  const list = await getExercises(user.id, filters);
+
+  const t = await getTranslations({
+    locale: typedLocale,
+    namespace: 'exercises',
+  });
+
+  const buildHref = (
+    override: Partial<{
+      type: ExerciseTypeFilter;
+      muscle: string | null;
+      ownership: ExerciseOwnership;
+      q: string | null;
+    }>,
+  ) => {
+    const nextType = override.type ?? type;
+    const nextMuscle = 'muscle' in override ? override.muscle : muscle;
+    const nextOwnership = override.ownership ?? ownership;
+    const nextSearch = 'q' in override ? override.q : search;
+
+    const usp = new URLSearchParams();
+    if (nextType !== 'all') usp.set('type', nextType);
+    if (nextMuscle) usp.set('muscle', nextMuscle);
+    if (nextOwnership !== 'all') usp.set('ownership', nextOwnership);
+    if (nextSearch) usp.set('q', nextSearch);
+    const qs = usp.toString();
+    return `/${typedLocale}/exercises${qs ? `?${qs}` : ''}`;
+  };
+
+  const typeOptions: ExerciseTypeFilter[] = ['all', 'strength', 'cardio'];
+  const ownershipOptions: ExerciseOwnership[] = ['all', 'mine', 'public'];
+
+  const hasActiveFilter =
+    type !== 'all' || ownership !== 'all' || muscle !== null || search !== null;
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-16">
+      <header className="mb-10">
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          {t('eyebrow')}
+        </p>
+        <h1 className="mt-3 font-display text-4xl leading-tight text-foreground sm:text-5xl">
+          {t('title')}
+        </h1>
+        <p className="mt-3 text-base text-muted-foreground">{t('subtitle')}</p>
+      </header>
+
+      {/* Recherche (form GET, sans JS) */}
+      <form
+        method="get"
+        action={`/${typedLocale}/exercises`}
+        className="mb-6 flex flex-wrap gap-3"
+        role="search"
+      >
+        {type !== 'all' && <input type="hidden" name="type" value={type} />}
+        {ownership !== 'all' && (
+          <input type="hidden" name="ownership" value={ownership} />
+        )}
+        {muscle && <input type="hidden" name="muscle" value={muscle} />}
+        <label htmlFor="search" className="sr-only">
+          {t('search.label')}
+        </label>
+        <input
+          id="search"
+          name="q"
+          type="search"
+          defaultValue={search ?? ''}
+          placeholder={t('search.placeholder')}
+          maxLength={80}
+          className="min-h-11 flex-1 border-2 border-foreground bg-background px-4 font-mono text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground"
+        />
+        <button
+          type="submit"
+          className="inline-flex min-h-11 items-center border-2 border-foreground bg-foreground px-5 font-mono text-xs uppercase tracking-widest text-background transition hover:bg-foreground/90"
+        >
+          {t('search.submit')}
+        </button>
+      </form>
+
+      {/* Filtres */}
+      <section
+        aria-labelledby="filters-heading"
+        className="mb-8 border-2 border-foreground p-6"
+      >
+        <h2
+          id="filters-heading"
+          className="font-mono text-xs uppercase tracking-widest text-muted-foreground"
+        >
+          {t('filters.label')}
+        </h2>
+
+        <div className="mt-5 grid gap-6 sm:grid-cols-2">
+          <FilterGroup label={t('filters.type.label')}>
+            {typeOptions.map((ty) => (
+              <FilterPill
+                key={ty}
+                active={ty === type}
+                href={buildHref({ type: ty })}
+                label={t(`filters.type.${ty}`)}
+              />
+            ))}
+          </FilterGroup>
+
+          <FilterGroup label={t('filters.ownership.label')}>
+            {ownershipOptions.map((o) => (
+              <FilterPill
+                key={o}
+                active={o === ownership}
+                href={buildHref({ ownership: o })}
+                label={t(`filters.ownership.${o}`)}
+              />
+            ))}
+          </FilterGroup>
+        </div>
+
+        {list.availableMuscles.length > 0 && (
+          <div className="mt-6">
+            <p className="mb-2 font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+              {t('filters.muscle.label')}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <FilterPill
+                active={muscle === null}
+                href={buildHref({ muscle: null })}
+                label={t('filters.muscle.all')}
+              />
+              {list.availableMuscles.map((m) => (
+                <FilterPill
+                  key={m}
+                  active={m === muscle}
+                  href={buildHref({ muscle: m })}
+                  label={m}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {hasActiveFilter && (
+          <Link
+            href={`/${typedLocale}/exercises`}
+            className="mt-6 inline-flex min-h-11 items-center font-mono text-xs uppercase tracking-widest underline-offset-4 hover:underline"
+          >
+            ← {t('filters.reset')}
+          </Link>
+        )}
+      </section>
+
+      {/* Comptage */}
+      <p
+        className="mb-4 font-mono text-xs uppercase tracking-widest text-muted-foreground"
+        aria-live="polite"
+      >
+        {t('totalCount', { count: list.totalCount })}
+      </p>
+
+      {/* Liste / Empty */}
+      {list.items.length === 0 ? (
+        <section className="border-2 border-foreground p-8 text-center">
+          <p className="font-mono text-xs uppercase tracking-widest text-muted-foreground">
+            {t('empty.label')}
+          </p>
+          <p className="mt-3 font-display text-2xl leading-snug text-foreground">
+            {t('empty.body')}
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {t('empty.subtext')}
+          </p>
+        </section>
+      ) : (
+        <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {list.items.map((ex) => (
+            <li key={ex.id}>
+              <article className="group flex h-full flex-col border-2 border-foreground p-5 transition hover:bg-muted">
+                <header className="mb-3 flex items-baseline justify-between gap-3">
+                  <h3 className="font-display text-lg leading-snug text-foreground break-words">
+                    {ex.name}
+                  </h3>
+                  {ex.isMine && (
+                    <span className="shrink-0 font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+                      {t('badge.mine')}
+                    </span>
+                  )}
+                </header>
+                <dl className="space-y-1 font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+                  {ex.muscleGroup && (
+                    <div className="flex justify-between gap-3">
+                      <dt>{t('field.muscle')}</dt>
+                      <dd className="text-foreground">{ex.muscleGroup}</dd>
+                    </div>
+                  )}
+                  {ex.exerciseType && (
+                    <div className="flex justify-between gap-3">
+                      <dt>{t('field.type')}</dt>
+                      <dd className="text-foreground">{ex.exerciseType}</dd>
+                    </div>
+                  )}
+                  {ex.equipmentName && (
+                    <div className="flex justify-between gap-3">
+                      <dt>{t('field.equipment')}</dt>
+                      <dd className="text-foreground">{ex.equipmentName}</dd>
+                    </div>
+                  )}
+                  {ex.difficulty !== null && ex.difficulty > 0 && (
+                    <div className="flex justify-between gap-3">
+                      <dt>{t('field.difficulty')}</dt>
+                      <dd className="text-foreground">
+                        {'★'.repeat(Math.min(ex.difficulty, 5))}
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+              </article>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {list.totalCount > list.items.length && (
+        <p className="mt-6 font-mono text-xs uppercase tracking-widest text-muted-foreground">
+          {t('truncated', {
+            shown: list.items.length,
+            total: list.totalCount,
+          })}
+        </p>
+      )}
+
+      <nav className="mt-10 font-mono text-xs uppercase tracking-widest">
+        <Link
+          href={`/${typedLocale}/dashboard`}
+          className="inline-flex min-h-11 items-center py-2 underline-offset-4 hover:underline"
+        >
+          ← {t('back')}
+        </Link>
+      </nav>
+    </main>
+  );
+}
+
+function FilterGroup({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="mb-2 font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </p>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </div>
+  );
+}
+
+function FilterPill({
+  active,
+  href,
+  label,
+}: {
+  active: boolean;
+  href: string;
+  label: string;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={active ? 'page' : undefined}
+      className={
+        active
+          ? 'inline-flex min-h-11 items-center border-2 border-foreground bg-foreground px-4 font-mono text-xs uppercase tracking-widest text-background'
+          : 'inline-flex min-h-11 items-center border-2 border-foreground px-4 font-mono text-xs uppercase tracking-widest text-foreground transition hover:bg-muted'
+      }
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -221,7 +221,8 @@
         "viewAll": "View full history"
       }
     },
-    "historyLink": "View full history"
+    "historyLink": "View full history",
+    "exercisesLink": "Exercise library"
   },
   "profile": {
     "metaTitle": "My profile",
@@ -428,6 +429,53 @@
     },
     "loadMore": "Load more",
     "endOfList": "End of history."
+  },
+  "exercises": {
+    "eyebrow": "LIBRARY",
+    "title": "Your exercises.",
+    "subtitle": "Your own exercises + public ones, filterable.",
+    "back": "Back to dashboard",
+    "search": {
+      "label": "Search an exercise",
+      "placeholder": "Search by name…",
+      "submit": "Search"
+    },
+    "filters": {
+      "label": "FILTERS",
+      "type": {
+        "label": "Type",
+        "all": "All",
+        "strength": "Strength",
+        "cardio": "Cardio"
+      },
+      "ownership": {
+        "label": "Origin",
+        "all": "All",
+        "mine": "My exercises",
+        "public": "Public"
+      },
+      "muscle": {
+        "label": "Muscle group",
+        "all": "All"
+      },
+      "reset": "Reset"
+    },
+    "totalCount": "{count, plural, =0 {no exercise} one {# exercise} other {# exercises}}",
+    "truncated": "Showing {shown} of {total}. Refine your filters to see more.",
+    "empty": {
+      "label": "NOTHING TO SHOW",
+      "body": "No exercise for these filters.",
+      "subtext": "Change the type or muscle, or reset the filters."
+    },
+    "badge": {
+      "mine": "MINE"
+    },
+    "field": {
+      "muscle": "Muscle",
+      "type": "Type",
+      "equipment": "Equipment",
+      "difficulty": "Difficulty"
+    }
   },
   "workoutDetail": {
     "eyebrow": "WORKOUT",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -221,7 +221,8 @@
         "viewAll": "Voir tout l'historique"
       }
     },
-    "historyLink": "Voir tout l'historique"
+    "historyLink": "Voir tout l'historique",
+    "exercisesLink": "Bibliothèque d'exercices"
   },
   "profile": {
     "metaTitle": "Mon profil",
@@ -428,6 +429,53 @@
     },
     "loadMore": "Charger plus",
     "endOfList": "Fin de l'historique."
+  },
+  "exercises": {
+    "eyebrow": "BIBLIOTHÈQUE",
+    "title": "Tes exercices.",
+    "subtitle": "Tes exercices perso + les exercices publics, filtrables.",
+    "back": "Retour au dashboard",
+    "search": {
+      "label": "Rechercher un exercice",
+      "placeholder": "Chercher par nom…",
+      "submit": "Chercher"
+    },
+    "filters": {
+      "label": "FILTRES",
+      "type": {
+        "label": "Type",
+        "all": "Tous",
+        "strength": "Musculation",
+        "cardio": "Cardio"
+      },
+      "ownership": {
+        "label": "Origine",
+        "all": "Tous",
+        "mine": "Mes exercices",
+        "public": "Publics"
+      },
+      "muscle": {
+        "label": "Groupe musculaire",
+        "all": "Tous"
+      },
+      "reset": "Réinitialiser"
+    },
+    "totalCount": "{count, plural, =0 {aucun exercice} one {# exercice} other {# exercices}}",
+    "truncated": "Affichage de {shown} sur {total}. Affine tes filtres pour voir le reste.",
+    "empty": {
+      "label": "RIEN À AFFICHER",
+      "body": "Pas d'exercice pour ces filtres.",
+      "subtext": "Change le type ou le muscle, ou réinitialise les filtres."
+    },
+    "badge": {
+      "mine": "PERSO"
+    },
+    "field": {
+      "muscle": "Muscle",
+      "type": "Type",
+      "equipment": "Équipement",
+      "difficulty": "Difficulté"
+    }
   },
   "workoutDetail": {
     "eyebrow": "SÉANCE",

--- a/src/i18n/messages/nl.json
+++ b/src/i18n/messages/nl.json
@@ -221,7 +221,8 @@
         "viewAll": "Volledige geschiedenis"
       }
     },
-    "historyLink": "Volledige geschiedenis"
+    "historyLink": "Volledige geschiedenis",
+    "exercisesLink": "Oefeningenbibliotheek"
   },
   "profile": {
     "metaTitle": "Mijn profiel",
@@ -428,6 +429,53 @@
     },
     "loadMore": "Meer laden",
     "endOfList": "Einde van de geschiedenis."
+  },
+  "exercises": {
+    "eyebrow": "BIBLIOTHEEK",
+    "title": "Je oefeningen.",
+    "subtitle": "Je eigen oefeningen + de publieke, filterbaar.",
+    "back": "Terug naar dashboard",
+    "search": {
+      "label": "Zoek een oefening",
+      "placeholder": "Zoeken op naam…",
+      "submit": "Zoeken"
+    },
+    "filters": {
+      "label": "FILTERS",
+      "type": {
+        "label": "Type",
+        "all": "Alle",
+        "strength": "Krachttraining",
+        "cardio": "Cardio"
+      },
+      "ownership": {
+        "label": "Herkomst",
+        "all": "Alle",
+        "mine": "Mijn oefeningen",
+        "public": "Publiek"
+      },
+      "muscle": {
+        "label": "Spiergroep",
+        "all": "Alle"
+      },
+      "reset": "Herstellen"
+    },
+    "totalCount": "{count, plural, =0 {geen oefening} one {# oefening} other {# oefeningen}}",
+    "truncated": "{shown} van {total} getoond. Verfijn je filters om de rest te zien.",
+    "empty": {
+      "label": "NIETS TE TONEN",
+      "body": "Geen oefening voor deze filters.",
+      "subtext": "Wijzig het type of de spier, of herstel de filters."
+    },
+    "badge": {
+      "mine": "EIGEN"
+    },
+    "field": {
+      "muscle": "Spier",
+      "type": "Type",
+      "equipment": "Materiaal",
+      "difficulty": "Moeilijkheid"
+    }
   },
   "workoutDetail": {
     "eyebrow": "SESSIE",

--- a/src/lib/exercises/index.ts
+++ b/src/lib/exercises/index.ts
@@ -1,0 +1,123 @@
+import { createServerClient } from '@/lib/supabase';
+
+import {
+  EXERCISES_PAGE_SIZE,
+  EXERCISE_TYPE_DB_MAP,
+  exerciseListSchema,
+  type ExerciseFilters,
+  type ExerciseItem,
+  type ExerciseList,
+} from './schema';
+
+/**
+ * Retourne la bibliothèque d'exercices visible pour l'utilisateur courant :
+ * ses exercices privés + les exercices publics.
+ *
+ * - RLS Supabase : un user ne voit JAMAIS les exercices privés d'un autre user.
+ * - `.or('user_id.eq.X,is_public.eq.true')` en defense-in-depth.
+ * - Pas de pagination cursor pour le moment : la bibliothèque reste petite
+ *   (< quelques centaines de lignes). On tronque à EXERCISES_PAGE_SIZE et on
+ *   invite à affiner les filtres si besoin.
+ */
+export async function getExercises(
+  userId: string,
+  filters: ExerciseFilters,
+): Promise<ExerciseList> {
+  const supabase = await createServerClient();
+
+  let query = supabase
+    .from('exercises')
+    .select(
+      'id, name, muscle_group, exercise_type, equipment_id, difficulty, image_url, is_public, user_id, equipment:equipment(name)',
+      { count: 'exact' },
+    )
+    .or(`user_id.eq.${userId},is_public.eq.true`)
+    .order('name', { ascending: true })
+    .limit(EXERCISES_PAGE_SIZE);
+
+  if (filters.type !== 'all') {
+    query = query.eq('exercise_type', EXERCISE_TYPE_DB_MAP[filters.type]);
+  }
+  if (filters.muscle) {
+    query = query.eq('muscle_group', filters.muscle);
+  }
+  if (filters.ownership === 'mine') {
+    query = query.eq('user_id', userId);
+  } else if (filters.ownership === 'public') {
+    query = query.eq('is_public', true);
+  }
+  if (filters.search) {
+    // `ilike` pour une recherche insensible à la casse ; échappement des
+    // wildcards pour éviter les LIKE injection.
+    const escaped = filters.search.replace(/[%_\\]/g, (c) => `\\${c}`);
+    query = query.ilike('name', `%${escaped}%`);
+  }
+
+  const { data, error, count } = await query;
+
+  if (error) {
+    console.error('[exercises] query failed:', error.message);
+    return { items: [], totalCount: 0, availableMuscles: [] };
+  }
+
+  const items: ExerciseItem[] = (data ?? []).map((row) => {
+    const equipmentRel = row.equipment as
+      | { name: string }
+      | { name: string }[]
+      | null;
+    const equipmentName = Array.isArray(equipmentRel)
+      ? (equipmentRel[0]?.name ?? null)
+      : (equipmentRel?.name ?? null);
+
+    return {
+      id: row.id,
+      name: row.name,
+      muscleGroup: row.muscle_group,
+      exerciseType: row.exercise_type,
+      equipmentId: row.equipment_id,
+      equipmentName,
+      difficulty: row.difficulty,
+      imageUrl: row.image_url,
+      isPublic: row.is_public ?? false,
+      isMine: row.user_id === userId,
+    };
+  });
+
+  const availableMuscles = Array.from(
+    new Set(
+      items
+        .map((it) => it.muscleGroup)
+        .filter((m): m is string => Boolean(m && m.trim())),
+    ),
+  ).sort((a, b) => a.localeCompare(b));
+
+  const parsed = exerciseListSchema.safeParse({
+    items,
+    totalCount: count ?? items.length,
+    availableMuscles,
+  });
+
+  if (!parsed.success) {
+    console.error(
+      '[exercises] schema validation failed:',
+      parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`),
+    );
+    return { items: [], totalCount: 0, availableMuscles: [] };
+  }
+
+  return parsed.data;
+}
+
+export type {
+  ExerciseFilters,
+  ExerciseItem,
+  ExerciseList,
+  ExerciseOwnership,
+  ExerciseTypeFilter,
+} from './schema';
+export {
+  EXERCISES_PAGE_SIZE,
+  exerciseFiltersSchema,
+  exerciseOwnershipSchema,
+  exerciseTypeSchema,
+} from './schema';

--- a/src/lib/exercises/schema.ts
+++ b/src/lib/exercises/schema.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+/**
+ * Schémas Zod pour la bibliothèque d'exercices.
+ *
+ * Validation défensive en sortie Supabase (même pattern que dashboard /
+ * history / workouts). Sur dérive de schéma DB on log et on renvoie vide.
+ */
+
+export const EXERCISES_PAGE_SIZE = 40;
+
+export const exerciseTypeSchema = z.enum(['all', 'strength', 'cardio']);
+export type ExerciseTypeFilter = z.infer<typeof exerciseTypeSchema>;
+
+/**
+ * Mapping filtre UI -> valeurs stockées en base.
+ * La colonne `exercises.exercise_type` contient 'Musculation' | 'Cardio'.
+ */
+export const EXERCISE_TYPE_DB_MAP: Record<
+  Exclude<ExerciseTypeFilter, 'all'>,
+  string
+> = {
+  strength: 'Musculation',
+  cardio: 'Cardio',
+};
+
+export const exerciseOwnershipSchema = z.enum(['all', 'mine', 'public']);
+export type ExerciseOwnership = z.infer<typeof exerciseOwnershipSchema>;
+
+export const exerciseFiltersSchema = z.object({
+  type: exerciseTypeSchema.default('all'),
+  muscle: z.string().trim().min(1).max(40).nullable().default(null),
+  ownership: exerciseOwnershipSchema.default('all'),
+  search: z.string().trim().min(1).max(80).nullable().default(null),
+});
+export type ExerciseFilters = z.infer<typeof exerciseFiltersSchema>;
+
+export const exerciseItemSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  muscleGroup: z.string().nullable(),
+  exerciseType: z.string().nullable(),
+  equipmentId: z.number().nullable(),
+  equipmentName: z.string().nullable(),
+  difficulty: z.number().int().nullable(),
+  imageUrl: z.string().url().nullable(),
+  isPublic: z.boolean(),
+  isMine: z.boolean(),
+});
+export type ExerciseItem = z.infer<typeof exerciseItemSchema>;
+
+export const exerciseListSchema = z.object({
+  items: z.array(exerciseItemSchema).max(EXERCISES_PAGE_SIZE),
+  totalCount: z.number().int().nonnegative(),
+  /** Muscles distincts présents dans le résultat (pour alimenter le filtre). */
+  availableMuscles: z.array(z.string()),
+});
+export type ExerciseList = z.infer<typeof exerciseListSchema>;


### PR DESCRIPTION
## Summary
- Nouvelle page SSR `/[locale]/exercises` : grille brutaliste des exercices visibles (user + publics)
- Fetcher `getExercises()` avec RLS Supabase + `.or(user_id.eq,is_public.eq.true)` (defense-in-depth)
- Filtres full-SSR via URL : type, muscle group (dynamique), ownership, search par nom
- Search `ilike` insensible à la casse, **wildcards LIKE échappés** (pas d'injection)
- Validation Zod défensive en sortie Supabase
- Badge \"PERSO\" sur ses propres exercices
- Nav link depuis le dashboard
- i18n fr/nl/en complet

## Sécurité
- `requireUser()` → redirect /login si anonyme
- RLS + filtre explicite côté fetcher
- LIKE-injection : `[%_\\]` escape sur le terme de recherche
- Max length search=80, muscle=40 (évite les URLs abusives)
- Pas de leak d'info dans les logs (on log juste le message, pas le payload)

## Test plan
- [ ] `/fr/exercises` → grille affichée (exos user + publics)
- [ ] Filtre type=strength → ne reste que musculation
- [ ] Filtre muscle=Pectoraux → restrictions OK
- [ ] Ownership=mine → ne reste que mes exos (badge PERSO partout)
- [ ] Search \"bench\" avec % dedans → pas d'injection (LIKE escape)
- [ ] Anonyme → redirect /login
- [ ] NL + EN OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)