### PR TITLE
chore(governance): refactor CLAUDE.md

### DIFF
--- a/.claude/commands/design-audit.md
+++ b/.claude/commands/design-audit.md
@@ -26,7 +26,7 @@ Sinon, analyse le fichier actif dans l'éditeur.
 - [ ] Un seul bouton "primary" (orange plein) par section/écran
 - [ ] Boutons secondaires en `variant="outline"` ou `variant="ghost"`
 - [ ] Tous les boutons utilisent `<Button>` de `@/components/ui/button` (pas de `<button>` custom)
-- [ ] Taille minimale 44px (touch target WCAG)
+- [ ] Taille minimale ≥ 44px (56px pour actions critiques — touch target WCAG)
 
 ### 📐 Espacements & Cohérence
 - [ ] Espacements en multiples de 4px (Tailwind: p-1=4px, p-2=8px, p-4=16px...)

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -16,6 +16,8 @@ Tu es l'agent orchestrateur d'IronTrack. Tu coordonnes les autres agents selon l
 | Agent Performance | `.claude/agents/performance.md` | Référence performance |
 | Agent Accessibilité | `.claude/agents/accessibility.md` | Référence a11y |
 | Agent Sécurité | `.claude/agents/security.md` | Référence sécurité |
+| Agent Testing | `.claude/agents/testing.md` | Référence tests (Vitest, Playwright, jest-axe) |
+| Agent DevOps | `.claude/agents/devops.md` | Référence CI/CD, Vercel, env vars |
 
 ## DÉTECTION AUTOMATIQUE DE LA DEMANDE
 
@@ -47,3 +49,5 @@ Pour "améliore toute la page X" :
 6. **Touch targets** — minimum 44px pour tout élément cliquable
 7. **Composant < 200 lignes** — sinon diviser en sous-composants
 8. **Hooks avant tout** — early returns APRÈS les hooks React
+9. **Auth check avant Supabase** — toujours `auth.getUser()` puis RLS, aucune exception
+10. **Pas de `console.log` en production** — logger structuré uniquement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,101 @@
+# CHANGELOG — IronTrack
+
+Journal chronologique des changements structurels, corrections et décisions techniques. Format inspiré de [Keep a Changelog](https://keepachangelog.com/).
+
+Les règles projet vivent dans `CLAUDE.md`. La stack technique dans `docs/stack-and-cli.md`.
+
+---
+
+## [Non publié]
+
+### Gouvernance Claude
+- Refonte du `CLAUDE.md` en constitution ≤ 150 lignes (10 règles d'or + protocole d'invocation obligatoire).
+- Extraction de la stack technique vers `docs/stack-and-cli.md`.
+- Extraction du journal historique vers ce `CHANGELOG.md`.
+- Correction typographie dans les agents `ui-ux.md` et `performance.md` : `Inter` → `Fraunces + Manrope + JetBrains Mono` (DA officielle).
+- Nettoyage des gadgets : suppression de `agent-vibes/`, `personalities/`, `audio/`, `hooks/`, `plugins/`, `worktrees/angry-hofstadter/`, `background-music.cfg`, fichiers `tts-*.txt`, `.Codex/`.
+
+---
+
+## 2025-01-21 — Système d'administration
+
+Structure admin finale :
+```
+src/app/admin/
+├── layout.tsx
+├── page.tsx
+├── tickets/[id]/page.tsx
+├── users/page.tsx
+├── logs/page.tsx
+└── exports/page.tsx
+```
+
+---
+
+## 2025-01-20 — Corrections sécurité Supabase
+
+**Audit de sécurité Supabase corrigé** :
+1. ✅ Problème **SECURITY DEFINER View** (ERROR) — résolu
+2. ✅ Problèmes **SEARCH_PATH MUTABLE** (WARN x5) — résolu
+3. 📝 Protection **mots de passe compromis** (WARN) — guide créé
+
+---
+
+## 2025-01-20 — Système création/modification d'exercices
+
+### Formulaires clarifiés
+- **`ExerciseEditForm`** : modification des propriétés de l'exercice + affichage des notes de performance (lecture seule)
+- **`PerformanceEditForm`** : modification complète des performances avec toutes les métriques cardio avancées
+- **`ExerciseWizard`** : création d'exercices avec assistant intelligent
+- Bouton **« Modifier l'exercice »** ajouté au modal de détails pour clarifier les deux types de modification
+
+### Récupération des données
+- Notes proviennent désormais de la dernière performance (`performance_logs.notes`)
+- Toutes les métriques cardio avancées récupérées dans le formulaire d'édition de performance
+- Gestion des erreurs 404 corrigée
+
+### Modal de confirmation amélioré
+- Affichage complet de toutes les métriques (SPM, watts, heart rate, incline, cadence, resistance)
+- Affichage des notes si présentes
+- Résumé visuel avec icônes pour chaque métrique
+
+---
+
+## 2025-01-20 — Système cardio avancé
+
+### Formulaires de performance
+- Ajout de tous les champs cardio avancés : `stroke_rate`, `watts`, `heart_rate`, `incline`, `cadence`, `resistance`, `distance_unit`
+- Labels adaptés aux utilisateurs belges francophones
+- Sections spécifiques par équipement (rameur / course / vélo)
+- Unités correctes (mètres pour rameur, km pour course et vélo)
+
+### Navigation
+- Suppression de la page redondante `/exercises/[id]`
+- Correction des boutons « X » et « Retour » (redirection vers `/exercises`)
+- `ExerciseDetailsModal` comme interface principale de détail
+
+### Base de données
+- Script SQL exécuté pour ajouter les champs cardio avancés
+- Contraintes adaptées au système belge (mètres, km, virgule décimale)
+
+---
+
+## Notes techniques persistantes
+
+- Les notes d'exercices sont stockées dans `performance_logs.notes` (pas sur l'exercice lui-même).
+- L'équipement par défaut est **Machine** (ID: 1) avec fallback intelligent.
+- Les suggestions d'exercices utilisent l'API OpenAI pour l'assistance.
+- Tous les textes sont adaptés aux utilisateurs belges francophones.
+- Configuration MCP pour une intégration fluide avec Supabase.
+
+---
+
+## 📋 Prochaines améliorations possibles
+
+- [ ] Nettoyer les 121 `console.log` en production (règle d'or #10)
+- [ ] Éliminer les 36 occurrences de `any` (règle TS strict)
+- [ ] Remplacer les 15 `bg-[#...]` hardcodés par des tokens CSS (règle d'or #2)
+- [ ] Graphiques de progression pour les métriques cardio
+- [ ] Export des données de performance
+- [ ] Programmes d'entraînement personnalisés
+- [ ] Notifications de rappel d'entraînement

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,275 +1,86 @@
-# IronTrack - Notes de développement
+# IronTrack — Constitution Claude
 
-## 🤖 Système d'Agents & Commandes Claude Code
+> **Rôle de ce fichier** : règles non négociables pour tout agent Claude (Code ou Desktop) qui touche à IronTrack. Doit rester ≤ 150 lignes. Journal technique → `CHANGELOG.md`. Stack & CLI → `docs/stack-and-cli.md`.
 
-### Slash Commands disponibles
+## 🎯 Stack en une ligne
 
-| Commande         | Description                                                    |
-| ---------------- | -------------------------------------------------------------- |
-| `/design-audit`  | Audite design d'un fichier/page (couleurs, dark mode, boutons) |
-| `/code-review`   | Revue complète du code (TypeScript, hooks, sécurité)           |
-| `/fix-dark-mode` | Corrige les incohérences dark mode                             |
-| `/new-component` | Crée un composant conforme au design system                    |
-| `/orchestrate`   | Agent maître — délègue selon la demande                        |
+**Next.js 15.5.12** (App Router, TS strict) · **React 18.3.1** · **Tailwind v4** (@theme inline, oklch) · **shadcn new-york** · **Supabase** (RLS partout) · **Framer Motion** · **PWA** · **Belgique FR-BE**.
 
-### Agents de référence (`.claude/agents/`)
+Détails, versions, DB, CLI → `docs/stack-and-cli.md`.
 
-| Agent         | Fichier                           | Usage                             |
-| ------------- | --------------------------------- | --------------------------------- |
-| Orchestrateur | `.claude/agents/orchestrator.md`  | Coordination multi-agents         |
-| UI/UX         | `.claude/agents/ui-ux.md`         | Design system, tokens, composants |
-| Code Review   | `.claude/agents/code-review.md`   | Qualité, TypeScript, hooks        |
-| Architecture  | `.claude/agents/architecture.md`  | Next.js, SOLID, structure         |
-| Performance   | `.claude/agents/performance.md`   | Core Web Vitals, optimisation     |
-| Accessibilité | `.claude/agents/accessibility.md` | WCAG 2.2 AA                       |
-| Sécurité      | `.claude/agents/security.md`      | Supabase RLS, RGPD                |
+## 📌 LES 10 RÈGLES D'OR (non négociables)
 
-### Slash Commands (`.claude/commands/`)
-
-| Fichier                             | Commande         | Description                          |
-| ----------------------------------- | ---------------- | ------------------------------------ |
-| `.claude/commands/design-audit.md`  | `/design-audit`  | Audite design d'un fichier/page      |
-| `.claude/commands/code-review.md`   | `/code-review`   | Revue complète du code               |
-| `.claude/commands/fix-dark-mode.md` | `/fix-dark-mode` | Corrige incohérences dark mode       |
-| `.claude/commands/new-component.md` | `/new-component` | Crée un composant conforme           |
-| `.claude/commands/orchestrate.md`   | `/orchestrate`   | Agent maître — délègue selon demande |
-
-### Skills rapides (`skills/`)
-
-| Fichier                        | Contenu                               |
-| ------------------------------ | ------------------------------------- |
-| `skills/DESIGN_RULES.md`       | Règles design en référence rapide     |
-| `skills/COMPONENT_PATTERNS.md` | Templates composants prêts à l'emploi |
-
-## 📌 LES 10 RÈGLES D'OR (TOUJOURS RESPECTER)
-
-1. **🟠 Orange = CTA primaire uniquement** — pas de fond/décoration orange
-2. **🎨 Variables CSS = toujours** — `bg-card`, `text-foreground`, `border-border`
+1. **🟠 Orange = CTA primaire uniquement** — jamais de fond/décoration orange
+2. **🎨 Tokens CSS toujours** — `bg-card`, `text-foreground`, `border-border` (jamais `bg-[#...]`)
 3. **🔘 1 seul bouton primary** par vue/section
-4. **📦 `<Button>` shadcn toujours** — jamais de `<button>` HTML custom
-5. **🌙 Dark mode via variables CSS** — pas de `dark:bg-gray-800` partout
-6. **👆 Touch targets ≥ 44px** — tout élément interactif
+4. **📦 `<Button>` shadcn toujours** — jamais `<button>` HTML custom
+5. **🌙 Dark mode via tokens** — pas de `dark:bg-gray-800` partout
+6. **👆 Touch targets ≥ 44px** — tout élément interactif (56px pour actions critiques)
 7. **⚓ Hooks AVANT early returns** — règle absolue React
-8. **📏 Composant < 200 lignes** — diviser en sous-composants
-9. **🔒 Auth check avant Supabase** — toujours vérifier l'utilisateur
-10. **🚫 Pas de console.log** en production
-
----
-
-## Informations du projet
-
-- **Framework**: Next.js 15.3.5 avec TypeScript
-- **Base de données**: Supabase
-- **Styling**: Tailwind CSS + Framer Motion
-- **MCP Servers**: Configuration via mcp.json pour Supabase et autres services
-- **Pays**: Belgique (système métrique adapté)
-
-## Commandes importantes
-
-```bash
-npm run dev          # Lancer en développement
-npm run build        # Build de production
-npm run lint         # Vérifier les erreurs ESLint
-npm run typecheck    # Vérifier les erreurs TypeScript
-```
-
-## Structure de la base de données
-
-### Table `exercises`
-
-- Exercices de base (nom, type, groupe musculaire, équipement, difficulté)
-- Types: 'Musculation' ou 'Cardio'
-
-### Table `performance_logs`
-
-- Données de performance pour chaque exercice
-- **Métriques cardio avancées** (ajoutées récemment):
-  - `stroke_rate` (16-36 SPM pour rameur)
-  - `watts` (50-500W pour rameur)
-  - `heart_rate` (60-200 BPM)
-  - `incline` (0-15% pour tapis)
-  - `cadence` (50-120 RPM pour vélo)
-  - `resistance` (1-20 pour vélo)
-  - `distance_unit` ('km', 'm', 'miles')
-
-### Table `equipment`
-
-- Liste des équipements disponibles
-- Inclut: Rameur, Tapis de course, Vélo, etc.
-
-## Corrections récentes (2025-01-20)
-
-### ✅ Système cardio corrigé
-
-1. **Formulaires de performance**:
-   - Ajout de tous les champs cardio avancés
-   - Labels adaptés aux utilisateurs belges
-   - Sections spécifiques par équipement (rameur, course, vélo)
-   - Unités correctes (mètres pour rameur, km pour course)
-
-2. **Navigation corrigée**:
-   - Suppression de la page redondante `/exercises/[id]`
-   - Correction des boutons "X" et "Retour" (redirection vers `/exercises`)
-   - Modal ExerciseDetailsModal comme interface principale
-
-3. **Base de données**:
-   - Script SQL exécuté pour ajouter les champs cardio avancés
-   - Contraintes adaptées au système belge
-
-### ✅ Système création/modification d'exercices finalisé
-
-1. **Formulaires de modification clarifiés**:
-   - **ExerciseEditForm**: Modification des propriétés de l'exercice + affichage des notes de performance (lecture seule)
-   - **PerformanceEditForm**: Modification complète des performances avec toutes les métriques cardio avancées
-   - Bouton "Modifier l'exercice" ajouté au modal de détails pour clarifier les deux types de modification
-
-2. **Récupération des données corrigée**:
-   - Notes proviennent maintenant de la dernière performance (performance_logs.notes)
-   - Toutes les métriques cardio avancées récupérées dans le formulaire d'édition de performance
-   - Gestion des erreurs 404 corrigée
-
-3. **Modal de confirmation amélioré**:
-   - Affichage complet de toutes les métriques (SPM, watts, heart rate, incline, cadence, resistance)
-   - Affichage des notes si présentes
-   - Résumé visuel avec icônes pour chaque métrique
-
-### 📝 Architecture des formulaires
-
-- **ExerciseEditForm**: Modification des exercices + notes (lecture seule)
-- **PerformanceEditForm**: Modification des performances individuelles
-- **ExerciseWizard**: Création d'exercices avec assistant intelligent
-
-### 🎯 Métriques par équipement
-
-- **Rameur**: Distance (m), temps, SPM, watts, heart rate
-- **Course/Tapis**: Distance (km), temps, vitesse, inclinaison, heart rate
-- **Vélo**: Distance (km), temps, cadence (RPM), résistance, heart rate
-
-## Configuration MCP
-
-- **Gestion**: Via CLI `claude mcp add/list/remove` (stocké dans `~/.claude.json`)
-- **MCP actifs**: Context7, Supabase, Excalidraw, Vercel, Figma, Google Calendar, Gmail, Notion, Playwright
-- **Playwright MCP** (local): contrôle navigateur Chrome pour tests et scraping
-- **Commandes**: `claude mcp list` pour vérifier l'état, `claude mcp add <nom> npx <package>` pour ajouter
-
-## 🔧 Configuration CLI Complète - RÉFÉRENCE AUTONOME
-
-> ⚠️ **SÉCURITÉ** : Les credentials sont dans `.env.local` (jamais committé).
-> Utiliser `$SUPABASE_DB_URL`, `$SUPABASE_ACCESS_TOKEN`, `$VERCEL_TOKEN` depuis l'environnement.
-
-### ✅ Supabase CLI
-
-- **Project ID**: `taspdceblvmpvdjixyit`
-- **URL**: `https://taspdceblvmpvdjixyit.supabase.co`
-- **DB Password**: voir `.env.local` → `SUPABASE_DB_PASSWORD`
-- **Access Token**: voir `.env.local` → `SUPABASE_ACCESS_TOKEN`
-- **Connection String**: voir `.env.local` → `SUPABASE_DB_URL`
-
-**Commandes essentielles** :
-
-```bash
-npx supabase db push --db-url "$SUPABASE_DB_URL"
-npx supabase migration new nom_migration
-npx supabase link --project-ref taspdceblvmpvdjixyit
-```
-
-### ✅ Vercel CLI
-
-- **Token**: voir `.env.local` → `VERCEL_TOKEN`
-- **Org**: `thierry-vanmeeterens-projects`
-- **Project**: `irontrack`
-- **Production URL**: `https://iron-track-dusky.vercel.app`
-
-**Commandes essentielles** :
-
-```bash
-npx vercel --token "$VERCEL_TOKEN" deploy --prod
-npx vercel --token "$VERCEL_TOKEN" env add VARIABLE_NAME production
-npx vercel --token "$VERCEL_TOKEN" ls
-```
-
-### ✅ GitHub CLI
-
-- **Repo**: `https://github.com/thierryvm/IronTrack.git`
-- **Branch principale**: `main`
-
-**Commandes essentielles** :
-
-```bash
-gh repo view thierryvm/IronTrack
-gh pr create --title "titre" --body "description"
-gh issue list
-```
-
-### 🎯 Workflow Claude Code Autonome
-
-1. **Modifications DB** → Utiliser `npx supabase migration new` puis `npx supabase db push`
-2. **Déploiement** → Git push (auto-deploy Vercel) OU `npx vercel deploy --prod`
-3. **Debug production** → Utiliser les tokens pour accès direct CLI
-4. **Variables env** → `npx vercel env add` pour ajouter en production
-
-## 🧠 Mode Thinking Avancé de Claude Code
-
-### Comment l'utiliser :
-
-- **"think"** : Mode de réflexion de base
-- **"think harder"** ou **"think longer"** : Réflexion approfondie
-- **"use thinking ultrahardcore"** : Mode de réflexion maximum pour problèmes complexes
-
-## 📚 Références Documentation
-
-### Claude Code
-
-- **Documentation officielle** : https://docs.anthropic.com/en/docs/claude-code/overview
-
-### Supabase
-
-- **Documentation officielle** : https://supabase.com/docs
-
-## Notes importantes
-
-- Les notes d'exercices sont stockées dans `performance_logs.notes`
-- L'équipement par défaut est "Machine" (ID: 1) avec fallback intelligent
-- Les suggestions d'exercices utilisent l'API OpenAI pour l'assistance
-- Tous les textes sont adaptés aux utilisateurs belges francophones
-- Configuration MCP pour une intégration fluide avec Supabase
-
-## 🛡️ Rappels de Sécurité Critiques
-
-### 🚨 RÈGLES DE SÉCURITÉ ABSOLUES
-
-- **RÉPONDRE TOUJOURS EN FRANÇAIS** : Claude doit répondre uniquement en français pour tous les projets IronTrack
-- **FICHIERS SENSIBLES** : Ne jamais commiter les fichiers listés dans .gitignore (CAHIER_DES_CHARGES_UX.md, mcp.json, etc.)
-- **DONNÉES PERSONNELLES** : Respecter les contraintes RGPD pour tous les utilisateurs belges
-- **BASE DE DONNÉES** : Toujours utiliser les politiques RLS et SECURITY INVOKER pour les vues
-- **AUTHENTIFICATION** : Maintenir la sécurité Supabase avec middleware approprié
-
-## 🔒 Corrections de Sécurité (2025-01-20)
-
-### ✅ Audit de sécurité Supabase corrigé AVEC SUCCÈS
-
-1. **Problème SECURITY DEFINER View (ERROR)** ✅ **RÉSOLU**
-2. **Problèmes SEARCH_PATH MUTABLE (WARN x5)** ✅ **RÉSOLU**
-3. **Protection mots de passe compromis (WARN)**: Guide créé
-
-## ✅ SYSTÈME D'ADMINISTRATION COMPLET (2025-01-21)
-
-### 📁 Structure Admin Finale
-
-```
-src/app/admin/
-├── layout.tsx
-├── page.tsx
-├── tickets/[id]/page.tsx
-├── users/page.tsx
-├── logs/page.tsx
-└── exports/page.tsx
-```
-
-## Prochaines améliorations possibles
-
-- [ ] Amélioration design global (en cours — voir agents/ui-ux.md)
-- [ ] Graphiques de progression pour les métriques cardio
-- [ ] Export des données de performance
-- [ ] Programmes d'entraînement personnalisés
-- [ ] Notifications de rappel d'entraînement
+8. **📏 Composant < 200 lignes** — sinon découper
+9. **🔒 Auth check avant Supabase** — toujours `auth.getUser()` puis RLS
+10. **🚫 Pas de `console.log`** en production — logger structuré uniquement
+
+## 🧠 Protocole d'invocation OBLIGATOIRE
+
+**Avant d'écrire ne serait-ce qu'une ligne, Claude DOIT lire l'agent concerné.** Pas d'improvisation, pas de « je connais déjà ».
+
+| Déclencheur dans le prompt utilisateur | Agent à lire AVANT d'agir |
+|---|---|
+| design, UI, UX, couleur, token, composant shadcn, dark mode, harmonise, « c'est moche » | `.claude/agents/ui-ux.md` |
+| review, refactor, propre, `any`, console.log, hooks, qualité | `.claude/agents/code-review.md` |
+| structure, architecture, SOLID, pattern, découpage, organisation | `.claude/agents/architecture.md` |
+| LCP, CLS, INP, bundle, lazy, lent, Core Web Vitals | `.claude/agents/performance.md` |
+| a11y, accessible, WCAG, lecteur d'écran, clavier, contraste | `.claude/agents/accessibility.md` |
+| sécurité, RLS, auth, RGPD, OWASP, CSP, rate limit, prompt injection | `.claude/agents/security.md` |
+| test, vitest, playwright, couverture, jest-axe, TDD, E2E | `.claude/agents/testing.md` |
+| déploiement, Vercel, migration, CI, rollback, env var | `.claude/agents/devops.md` |
+| « améliore tout », tâche multi-dimension | `.claude/agents/orchestrator.md` (flow multi-agent) |
+
+**Slash commands disponibles** (`.claude/commands/`) : `/design-audit`, `/code-review`, `/fix-dark-mode`, `/new-component`, `/orchestrate`, `/css-check`.
+
+**Skills rapides** (`skills/`) : `DESIGN_RULES.md` (référence express), `COMPONENT_PATTERNS.md` (templates prêts à copier).
+
+## 🚦 Workflow standard (toute modif)
+
+1. **Comprendre le POURQUOI** avant de coder — si ambigu, poser 2-3 questions ciblées
+2. **Lire l'agent concerné** (cf. table ci-dessus)
+3. **Annoncer** les fichiers impactés et le plan
+4. **Coder** en respectant les 10 règles d'or
+5. **Quality gates** avant commit : `npm run lint && npm run typecheck && npm run test`
+6. **Commit conventionnel** : `type(scope): description` (feat/fix/refactor/test/docs/chore/security)
+
+## 🗣️ Langue & communication
+
+- **Réponses à Thierry** : toujours français (il ne parle pas bien anglais)
+- **Code** : commentaires EN, noms variables/fonctions EN
+- **Commits, PR, docs techniques (README)** : EN
+- **Documents produits pour Thierry** (rapports, plans) : FR
+- **Style** : résumé → plan → détail. Direct, pas de remplissage.
+
+## 🛡️ Règles de sécurité ABSOLUES
+
+- **Secrets** : uniquement `.env.local` (jamais committé) ou Vercel env. Tokens → `$SUPABASE_ACCESS_TOKEN`, `$SUPABASE_DB_URL`, `$VERCEL_TOKEN`.
+- **RLS activé sur 100% des tables Supabase** — aucune exception
+- **Auth check OBLIGATOIRE** avant toute lecture/écriture Supabase
+- **Validation Zod côté serveur** sur toutes les entrées (jamais confiance au client)
+- **RGPD Belgique** : pas de PII dans les logs, consentement explicite, droit à l'oubli
+- **Pas d'implémentation maison de crypto/auth** — bibliothèques éprouvées uniquement
+- Détails OWASP 2025 + menaces 2026 → `.claude/agents/security.md`
+
+## 🚫 Règles absolues (pour tout agent IA sur ce projet)
+
+1. **Ne jamais supprimer une feature** sans confirmation explicite de Thierry
+2. **Ne jamais changer le design system** sans validation (couleurs, typo, spacing)
+3. **Ne jamais committer** les fichiers listés dans `.gitignore` (.env.local, mcp.json, etc.)
+4. **Sujets ambigus** : présenter les options, ne jamais trancher seul
+5. **Signaler proactivement** : risques sécurité, dette technique, régression
+6. **1 session = 1 objectif** (feature OU bug OU refactor — jamais les trois)
+7. **Vérifier que le projet compile et se lance** AVANT de déclarer terminé
+
+## 📚 Références
+
+- Stack complète, versions exactes, schéma DB, commandes CLI → **`docs/stack-and-cli.md`**
+- Journal des corrections et décisions → **`CHANGELOG.md`**
+- Documentation Claude Code → https://docs.anthropic.com/en/docs/claude-code/overview
+- Documentation Supabase → https://supabase.com/docs

--- a/docs/stack-and-cli.md
+++ b/docs/stack-and-cli.md
@@ -1,0 +1,157 @@
+# Stack & CLI IronTrack — Référence technique
+
+> Doc de référence matérielle : versions exactes, schéma DB, commandes CLI autonomes. Règles projet → `CLAUDE.md`.
+
+## 🧱 Stack (versions réelles, source: `package.json`)
+
+| Couche | Techno | Version |
+|---|---|---|
+| Framework | Next.js | 15.5.12 (App Router, Turbopack) |
+| UI runtime | React | 18.3.1 |
+| Langage | TypeScript | strict: true, zéro `any` |
+| Styling | Tailwind CSS | v4 (CSS-first, `@theme inline`) |
+| Composants | shadcn/ui | style `new-york` |
+| Animation | Framer Motion | activé sur transitions principales |
+| Backend | Supabase | Auth + PostgreSQL + Storage + RLS |
+| Déploiement | Vercel | auto-deploy depuis `main` |
+| Format | PWA | manifest + service worker |
+| Pays / locale | Belgique FR-BE | système métrique, virgule décimale |
+
+**Fonts officielles** (ne pas dévier) :
+- **Titres** : Fraunces (display serif)
+- **Corps** : Manrope (sans-serif)
+- **Mono / chiffres** : JetBrains Mono
+
+## 🎨 Tokens de couleur (source: `src/app/theme.css`)
+
+Système OKLCH complet dark-first. Orange brand :
+- `--primary-500` : #ff6b00 (CTA)
+- `--primary-600` : #e55f00 (hover)
+- `--primary-700` : #bf5200 (active)
+
+Semantic tokens standards shadcn : `background`, `foreground`, `card`, `border`, `muted`, `accent`, `destructive`, `ring` — tous en oklch, synchronisés `:root` + `@theme inline`.
+
+## 🗄️ Schéma base de données (tables principales)
+
+### `exercises`
+Exercices de base — `id`, `name`, `type` (`'Musculation'` | `'Cardio'`), `muscle_group`, `equipment_id`, `difficulty`.
+
+### `performance_logs`
+Logs de performance. Champs de base : `reps`, `sets`, `weight_kg`, `duration_sec`, `distance_m`, `notes`.
+
+**Métriques cardio avancées** :
+- `stroke_rate` (16-36 SPM — rameur)
+- `watts` (50-500W — rameur)
+- `heart_rate` (60-200 BPM)
+- `incline` (0-15% — tapis)
+- `cadence` (50-120 RPM — vélo)
+- `resistance` (1-20 — vélo)
+- `distance_unit` (`'km'` | `'m'` | `'miles'`)
+
+### `equipment`
+Liste équipements : Machine (id=1, défaut), Rameur, Tapis de course, Vélo, etc.
+
+**Métriques par équipement** :
+- Rameur → distance (m), temps, SPM, watts, HR
+- Course/Tapis → distance (km), temps, vitesse, inclinaison, HR
+- Vélo → distance (km), temps, cadence (RPM), résistance, HR
+
+## 🔐 Sécurité DB — rappels critiques
+
+- **RLS activé sur TOUTES les tables** — aucune exception
+- **Vues** : toujours `SECURITY INVOKER` (jamais `SECURITY DEFINER`)
+- **Fonctions** : `SET search_path = public, pg_temp` (éviter `MUTABLE`)
+- **Service role key** : côté serveur uniquement, jamais `NEXT_PUBLIC_*`
+
+## 🛠️ CLI — Configuration autonome
+
+> ⚠️ Credentials dans `.env.local` (jamais committé). Utiliser les variables d'env, jamais en dur.
+
+### Supabase
+- **Project ID** : `taspdceblvmpvdjixyit`
+- **URL** : `https://taspdceblvmpvdjixyit.supabase.co`
+- **Vars env** : `SUPABASE_DB_URL`, `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`
+
+```bash
+# Migrations (workflow obligatoire)
+npx supabase migration new nom_descriptif
+# → éditer supabase/migrations/[timestamp]_nom.sql
+npx supabase db push --db-url "$SUPABASE_DB_URL"
+npx supabase migration list --db-url "$SUPABASE_DB_URL"
+
+# Lien projet
+npx supabase link --project-ref taspdceblvmpvdjixyit
+```
+
+### Vercel
+- **Org** : `thierry-vanmeeterens-projects`
+- **Project** : `irontrack`
+- **Production URL** : `https://iron-track-dusky.vercel.app`
+- **Var env** : `VERCEL_TOKEN`
+
+```bash
+# Déploiement manuel
+npx vercel --token "$VERCEL_TOKEN" deploy --prod
+
+# Variables d'environnement
+npx vercel --token "$VERCEL_TOKEN" env add VARIABLE_NAME production
+npx vercel --token "$VERCEL_TOKEN" env ls
+
+# Lister les déploiements
+npx vercel --token "$VERCEL_TOKEN" ls
+```
+
+### GitHub
+- **Repo** : `https://github.com/thierryvm/IronTrack.git`
+- **Branche principale** : `main` (protégée)
+
+```bash
+gh repo view thierryvm/IronTrack
+gh pr create --title "titre" --body "description"
+gh pr list
+gh issue list
+```
+
+## 🔌 MCP Servers actifs
+
+Configuration via CLI `claude mcp add/list/remove` (stocké dans `~/.claude.json`).
+
+Serveurs attendus : **Context7**, **Supabase**, **Vercel**, **Figma**, **Playwright** (navigateur local pour tests/scraping), **Google Calendar**, **Gmail**, **Notion**, **Excalidraw**.
+
+```bash
+claude mcp list                    # vérifier l'état
+claude mcp add <nom> npx <package> # ajouter un serveur
+```
+
+## 📜 Scripts npm
+
+```bash
+npm run dev          # Lancer en développement (Turbopack)
+npm run build        # Build de production
+npm run lint         # ESLint
+npm run typecheck    # TypeScript --noEmit
+npm run test         # Vitest
+npm run test:coverage # Avec couverture
+```
+
+## 🚀 Workflow déploiement standard
+
+1. **Modif DB** → `npx supabase migration new` puis `npx supabase db push`
+2. **Commit** → `git commit -m "type(scope): description"` (conventional)
+3. **Push** → `git push origin main` (auto-deploy Vercel)
+4. **Vérification** → `https://iron-track-dusky.vercel.app` + Vercel dashboard
+
+## 🧠 Mode Thinking Claude Code
+
+Déclencheurs dans le prompt :
+- **`think`** — réflexion de base
+- **`think harder`** / **`think longer`** — réflexion approfondie
+- **`use thinking ultrahardcore`** — problèmes complexes
+
+## 📚 Documentation externe
+
+- Claude Code : https://docs.anthropic.com/en/docs/claude-code/overview
+- Supabase : https://supabase.com/docs
+- Next.js : https://nextjs.org/docs
+- Tailwind v4 : https://tailwindcss.com/docs/v4-beta
+- shadcn/ui : https://ui.shadcn.com


### PR DESCRIPTION
Split monolithic CLAUDE.md (276 lines) into:
- CLAUDE.md (86 lines): constitution with 10 golden rules + mandatory agent invocation protocol
- docs/stack-and-cli.md: stack versions (Next 15.5.12, React 18.3.1), DB schema, CLI commands
- CHANGELOG.md: historical technical journal (2025-01-20 cardio, admin, security fixes)

Local-only (gitignored): corrected Inter -> Fraunces+Manrope in .claude/agents/ui-ux.md and performance.md.