### PR TITLE
chore(docs): Step 0 — sync docs with reality before refonte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ Les règles projet vivent dans `CLAUDE.md`. La stack technique dans `docs/stack-
 
 ---
 
+## 2026-04-18 — Audit dette code (inventaire 69bb518)
+
+Mesures réelles sur `src/**` vs chiffres historiquement annoncés dans ce CHANGELOG :
+
+| Item | Annoncé | Mesuré | État |
+|---|---|---|---|
+| `console.log` en production | 121 | **0** (16 `console.error` légitimes en handlers d'erreur serveur) | ✅ résolu |
+| `any` (`: any`, `as any`, `<any>`) | 36 | **0** | ✅ résolu |
+| `bg-[#…]` / `text-[#…]` / `border-[#…]` hardcodés | 15 | **0** | ✅ résolu |
+
+Aucun code modifié dans cette entrée — il s'agit de la correction du CHANGELOG lui-même pour refléter la réalité du repo. Détails dans `docs/irontrack-inventory.md` §8.1.
+
+Divergences doc ↔ réalité corrigées en parallèle dans le même commit : `docs/stack-and-cli.md` synchronisé avec `package.json` (Next ^16, React ^19, retrait Framer Motion, PWA service worker marqué absent).
+
+---
+
 ## 2025-01-21 — Système d'administration
 
 Structure admin finale :
@@ -92,9 +108,8 @@ src/app/admin/
 
 ## 📋 Prochaines améliorations possibles
 
-- [ ] Nettoyer les 121 `console.log` en production (règle d'or #10)
-- [ ] Éliminer les 36 occurrences de `any` (règle TS strict)
-- [ ] Remplacer les 15 `bg-[#...]` hardcodés par des tokens CSS (règle d'or #2)
+> Les 3 items dette tech (`console.log`, `any`, `bg-[#…]`) initialement listés ici ont été vérifiés le 2026-04-18 : 0/0/0 mesuré. Retirés de la liste ci-dessous. Voir entrée `2026-04-18` plus haut.
+
 - [ ] Graphiques de progression pour les métriques cardio
 - [ ] Export des données de performance
 - [ ] Programmes d'entraînement personnalisés

--- a/docs/migration-audit-2026-04.md
+++ b/docs/migration-audit-2026-04.md
@@ -1,0 +1,103 @@
+# Migration audit — 2026-04-18
+
+Audit ponctuel des migrations Supabase suite à la divergence repérée dans
+l'inventaire `docs/irontrack-inventory.md`.
+
+## Constat
+
+`src/lib/profile/index.ts` (ligne 11-13) mentionne une migration qui ajoute
+une colonne `locale` à `profiles` :
+
+```ts
+// `locale` a été ajouté par la migration 20260417120457 : le type généré peut
+// être périmé → on étend explicitement.
+export type Profile = Tables<'profiles'> & {
+  locale?: string | null;
+};
+```
+
+## Résultat de la recherche
+
+| Vérification | Résultat |
+|---|---|
+| Présence dans `supabase/migrations/` | ❌ absente (72 migrations, toutes datées 2025-07-23 → 2025-08-17) |
+| Trace dans git (toutes branches, historique complet) | ❌ aucune — ni `git log --grep`, ni `git log -S"locale"`, ni `git log -- "*locale*"` |
+| Présence dans types auto-générés (`src/lib/supabase/types.ts`, daté 2026-04-15) | ❌ aucune colonne `locale` dans `profiles.Row` |
+| Référence dans le code applicatif | ✅ 1 seule : le commentaire de `src/lib/profile/index.ts` |
+
+## Diagnostic
+
+Trois hypothèses plausibles :
+
+1. **Migration appliquée hors-workflow** : `ALTER TABLE profiles ADD COLUMN locale TEXT`
+   exécutée directement depuis la dashboard Supabase (SQL editor) ou via
+   `supabase db push` avec un fichier local non committé. Aucune trace dans le
+   repo.
+2. **Migration planifiée mais jamais exécutée** : le commentaire du code
+   anticipe une migration future, le type est étendu défensivement au cas où.
+3. **Migration perdue lors d'un rebase** : peu probable — aucun reflog ni
+   stash n'en conserve la trace.
+
+**Risque** : un nouvel environnement bootstrappé à partir du repo (CI, dev
+machine neuve, preview Vercel avec base fraîche) n'aura **pas** la colonne
+`locale`. Toute lecture via `profile.locale` retournera `undefined` silencieux
+grâce au typage défensif, mais toute tentative d'**écriture** échouerait.
+
+## Vérification à faire côté Supabase prod
+
+À exécuter sur la base prod `taspdceblvmpvdjixyit` pour confirmer l'état :
+
+```sql
+SELECT column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'profiles'
+  AND column_name = 'locale';
+```
+
+- **Si ligne retournée** : la colonne existe → migration appliquée hors-workflow.
+  Action : créer une migration de rattrapage (`CREATE ... IF NOT EXISTS`) et
+  la committer pour la reproductibilité, puis régénérer les types.
+- **Si vide** : la colonne n'existe pas → le commentaire de `profile/index.ts`
+  anticipe à tort. Action : retirer le commentaire et l'extension de type, ou
+  créer la migration manquante si la feature locale-per-user est prévue.
+
+## Migration de rattrapage proposée (défensive, idempotente)
+
+Si la vérification confirme que la colonne existe bien en prod, committer ce
+fichier sous `supabase/migrations/20260417120457_add_profiles_locale.sql` pour
+rattraper l'historique :
+
+```sql
+-- Rattrapage : colonne profiles.locale (appliquée hors-workflow le 2026-04-17).
+-- Defensive: idempotent (IF NOT EXISTS) + valeur par défaut + index léger.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS locale TEXT;
+
+-- Contrainte : l'app n'accepte que fr/nl/en (cf. LOCALES dans src/i18n/request.ts).
+-- Ajouter une CHECK constraint via une deuxième migration si la contrainte est
+-- désirée côté DB (pour l'instant la validation vit côté app uniquement).
+
+COMMENT ON COLUMN public.profiles.locale IS
+  'Locale préférée de l''utilisateur (fr/nl/en). NULL = fallback sur Accept-Language ou DEFAULT_LOCALE.';
+```
+
+**Étapes post-migration** :
+1. `npx supabase db push --db-url "$SUPABASE_DB_URL"` (appliquera `IF NOT EXISTS` sans casser)
+2. `npm run db:types` → régénère `src/lib/supabase/types.ts` avec la colonne
+3. Supprimer l'extension défensive dans `src/lib/profile/index.ts` (plus nécessaire une fois les types à jour)
+
+## Action recommandée — Step 0.5 ou suivant
+
+Cette PR (`chore/docs-sync-reality`) **n'applique pas** la migration de
+rattrapage. Objectif du Step 0 = alignement doc uniquement. La décision
+d'appliquer ou non cette migration relève d'une PR séparée :
+- soit après vérification prod si la colonne existe déjà
+- soit au moment d'implémenter la persistance de la locale par utilisateur
+
+## Contexte lié
+
+- Inventaire complet : `docs/irontrack-inventory.md` §6.4 (migrations) et §4.2
+  (colonnes profiles utilisées vs disponibles)
+- Workflow migrations officiel : `docs/stack-and-cli.md` §🛠️ CLI Supabase

--- a/docs/stack-and-cli.md
+++ b/docs/stack-and-cli.md
@@ -1,20 +1,27 @@
 # Stack & CLI IronTrack — Référence technique
 
 > Doc de référence matérielle : versions exactes, schéma DB, commandes CLI autonomes. Règles projet → `CLAUDE.md`.
+>
+> **Synchronisé avec `package.json` le 2026-04-18** (commit `chore/docs-sync-reality`). Toute divergence constatée entre ce document et `package.json` doit être corrigée ici, pas l'inverse.
 
 ## 🧱 Stack (versions réelles, source: `package.json`)
 
 | Couche | Techno | Version |
 |---|---|---|
-| Framework | Next.js | 15.5.12 (App Router, Turbopack) |
-| UI runtime | React | 18.3.1 |
-| Langage | TypeScript | strict: true, zéro `any` |
-| Styling | Tailwind CSS | v4 (CSS-first, `@theme inline`) |
-| Composants | shadcn/ui | style `new-york` |
-| Animation | Framer Motion | activé sur transitions principales |
-| Backend | Supabase | Auth + PostgreSQL + Storage + RLS |
+| Framework | Next.js | `^16.0.0` (App Router, Turbopack) |
+| UI runtime | React | `^19.0.0` (React DOM `^19.0.0`) |
+| Langage | TypeScript | `^5.9.3`, strict: true, zéro `any` |
+| Styling | Tailwind CSS | `^4.1.11` (CSS-first, `@theme inline`, plugin `@tailwindcss/postcss`) |
+| Composants | shadcn/ui | style `new-york` (Radix UI primitives + `class-variance-authority`) |
+| Animation | CSS natif | keyframes `@keyframes rise`, transitions Tailwind, custom easing tokens (`--ease-standard`, `--ease-out`). **Pas de `framer-motion`** dans les dépendances. |
+| i18n | `next-intl` | `^4.9.1` (FR/NL/EN, routing `localePrefix: 'as-needed'`) |
+| Validation | Zod | `^3.25.76` |
+| Formulaires | React Hook Form | `^7.72.0` + `@hookform/resolvers` `^5.2.1` |
+| Icônes | Lucide | `lucide-react ^0.469.0` |
+| Backend | Supabase | `@supabase/ssr ^0.9.0` + `@supabase/supabase-js ^2.100.1` (Auth + PostgreSQL + Storage + RLS) |
 | Déploiement | Vercel | auto-deploy depuis `main` |
-| Format | PWA | manifest + service worker |
+| Format | PWA | manifest `public/manifest.webmanifest` uniquement — **pas de service worker** implémenté à date (offline non supporté) |
+| Runtime | Node | `>=20.0.0` (engines) |
 | Pays / locale | Belgique FR-BE | système métrique, virgule décimale |
 
 **Fonts officielles** (ne pas dévier) :
@@ -126,13 +133,18 @@ claude mcp add <nom> npx <package> # ajouter un serveur
 ## 📜 Scripts npm
 
 ```bash
-npm run dev          # Lancer en développement (Turbopack)
+npm run dev          # Lancer en développement (Turbopack, port 3000)
 npm run build        # Build de production
-npm run lint         # ESLint
+npm run start        # Serveur de production (port 3000)
+npm run lint         # ESLint (src/**/*.{ts,tsx})
 npm run typecheck    # TypeScript --noEmit
-npm run test         # Vitest
-npm run test:coverage # Avec couverture
+npm run format       # Prettier (src/**/*.{ts,tsx,css})
+npm run db:types     # Régénérer src/lib/supabase/types.ts
+npm run db:push      # supabase db push
+npm run db:migration # supabase migration new
 ```
+
+> ⚠️ **Tests** : `playwright.config.ts` et `jest.config.js` existent dans le repo, mais ni `@playwright/test` ni `vitest`/`jest` ne sont déclarés dans `package.json`. Aucun script `test` n'est exposé. Les fichiers sous `tests/e2e/` ne peuvent pas s'exécuter sans installer Playwright séparément. Cf. inventaire `docs/irontrack-inventory.md` §8.5.
 
 ## 🚀 Workflow déploiement standard
 
@@ -155,3 +167,15 @@ Déclencheurs dans le prompt :
 - Next.js : https://nextjs.org/docs
 - Tailwind v4 : https://tailwindcss.com/docs/v4-beta
 - shadcn/ui : https://ui.shadcn.com
+
+## 🪜 Migration notes — Next.js 15 → 16 / React 18 → 19
+
+Le repo a été mis à niveau vers **Next 16 + React 19** (package.json pin `^16.0.0` / `^19.0.0`). Points d'attention pour les agents qui modifient du code :
+
+- **Server Components async** : `params` et `searchParams` sont des `Promise<T>` dans Next 15+ App Router. Toutes les `page.tsx` actuelles font déjà `const { locale } = await params;` — conserver ce pattern.
+- **React 19 APIs** : `useActionState` (remplace `useFormState`), `useFormStatus`, `useOptimistic` sont utilisables et déjà exploités (`src/app/[locale]/profile/profile-form.tsx`, `login-form.tsx`).
+- **`next/font`** : configuration actuelle (`Fraunces`, `Manrope`, `JetBrains_Mono` via `next/font/google`) reste stable en Next 16.
+- **Turbopack** : activé en dev (`--turbo`). Le build prod reste sur webpack par défaut.
+- **Métadonnées** : `export const metadata` + `generateMetadata` async supportés normalement.
+
+En cas de doute sur une API dépréciée, vérifier d'abord `package.json` puis la documentation Next.js avant de présumer d'un comportement Next 14/15.


### PR DESCRIPTION
## Contexte

Step 0 avant la refonte complète IronTrack (Phase 1). L'inventaire exhaustif (`docs/irontrack-inventory.md`, commit `69bb518`) a révélé trois mensonges de documentation qui risquent d'induire en erreur tout agent qui touchera au code. Cette PR corrige uniquement la doc, zéro code métier.

## Fichiers touchés

| Fichier | Commit | Action |
|---|---|---|
| `docs/stack-and-cli.md` | `12ab12f` | Sync complet avec `package.json` : Next `^16`, React `^19`, retrait Framer Motion, PWA SW marqué absent, scripts npm réalignés, section "Migration notes Next 15→16" ajoutée |
| `CHANGELOG.md` | `f735384` | Retrait des 3 items dette obsolètes (121 `console.log` / 36 `any` / 15 `bg-[#…]`) + nouvelle entrée `2026-04-18` avec tableau de mesure |
| `docs/migration-audit-2026-04.md` | `206de1e` | **Nouveau** — audit du gap `profiles.locale` (migration `20260417120457` introuvable), SQL de vérif prod + migration de rattrapage défensive |

## Preuves

### 1. `package.json` → `stack-and-cli.md` (versions réelles)

```
\"@supabase/ssr\": \"^0.9.0\"
\"@supabase/supabase-js\": \"^2.100.1\"
\"next\": \"^16.0.0\"
\"next-intl\": \"^4.9.1\"
\"react\": \"^19.0.0\"
\"react-dom\": \"^19.0.0\"
\"tailwindcss\": \"^4.1.11\"
\"typescript\": \"^5.9.3\"
\"zod\": \"^3.25.76\"
\"node\": \">=20.0.0\"
grep framer package.json  →  0 match
```

### 2. Dette mesurée sur `src/**` = 0/0/0

```
$ grep -r 'console\.log' src/                                → 0
$ grep -rE ':\s*any\b|\bas any\b|<any>' src/                 → 0
$ grep -rE 'bg-\[#|text-\[#|border-\[#' src/                 → 0
```

(16 `console.error` subsistent mais sont des handlers d'erreur serveur légitimes dans `src/lib/{dashboard,workouts,history,exercises,profile}` — documenté dans le CHANGELOG.)

### 3. Migration `profiles.locale` introuvable

```
$ git log --all --full-history -- 'supabase/migrations/*locale*'   → vide
$ git log --all -S'locale' --diff-filter=A -- 'supabase/migrations/'  → vide
$ ls supabase/migrations/ | grep -i '2026\|locale'                 → vide (72 fichiers, 2025-07 → 2025-08)
$ grep 'locale' src/lib/supabase/types.ts                          → 0 match (types régénérés 2026-04-15)
```

Seule référence dans le repo : commentaire dans `src/lib/profile/index.ts:12`. Documenté complètement dans `docs/migration-audit-2026-04.md` avec SQL de vérif prod et migration de rattrapage idempotente prête à committer après confirmation.

## Checklist alignement doc ↔ réalité

- [x] Next.js : doc `15.5.12` → réalité `^16.0.0` ✅ corrigé
- [x] React : doc `18.3.1` → réalité `^19.0.0` ✅ corrigé
- [x] Framer Motion : doc `activé` → réalité `absent` ✅ retiré
- [x] PWA : doc `manifest + SW` → réalité `manifest only` ✅ précisé
- [x] Scripts `test` / `test:coverage` : doc présents → réalité inexistants ✅ retirés (+ warning sur Playwright/Jest configs orphelins)
- [x] CHANGELOG dette `console.log/any/bg-[#]` : doc `121/36/15` → réalité `0/0/0` ✅ retiré
- [x] Migration `profiles.locale` : code dit `existe` → filesystem `absent` ✅ documenté (décision = PR suivante)

## Quality gates

- [x] Aucun code métier touché (`git diff --stat main..HEAD -- src/ components/ app/` → vide)
- [ ] CI verte — à surveiller après push
- [ ] Sourcery clean — à surveiller
- [ ] ⚠️ **`ROADMAP.md` mentionné dans le prompt n'existe pas** dans ce repo (vérifié : seul `node_modules/smart-buffer/docs/ROADMAP.md` match). Commit `43355e7` (référence CLAUDE.md) inconnu de `git show`. Si la règle existe vraiment, me pointer vers le fichier.

## Note

Tests e2e admin obsolètes (3 fichiers) = hors scope, traités en Step 0.5 séparément.

PR ouverte en **draft** — à passer en ready-for-review quand la CI sera verte. Attente du GO avant merge.

## Résumé par Sourcery

Aligner la documentation avec la stack actuelle d’IronTrack et la dette technique enregistrée, sans modifier le code de l’application.

Documentation :
- Mettre à jour la référence de stack pour refléter le framework, les bibliothèques, le runtime et la configuration PWA réellement utilisés d’après le `package.json`, y compris Next 16/React 19 et l’absence de Framer Motion et de service worker.
- Réviser la documentation des scripts npm pour qu’elle corresponde à l’ensemble réel des scripts et clarifier l’état actuel et les limites des tests automatisés ainsi que de la configuration des outils de test.
- Ajouter des notes de migration pour la mise à niveau Next.js 15→16 et React 18→19 afin de guider les futurs changements de code et l’usage des API.
- Corriger les chiffres de dette technique dans le CHANGELOG pour qu’ils correspondent à la base de code actuelle et documenter le nettoyage déjà effectué au lieu de le lister comme travail futur.
- Introduire un document d’audit de migration dédié décrivant la migration manquante de `profiles.locale`, ses risques, et un plan de remédiation défensif pour une PR de suivi.

<details>
<summary>Original summary in English</summary>

## Résumé par Sourcery

Aligner la documentation avec la pile actuelle d’IronTrack, les outils, et l’état des migrations de base de données, sans modifier le code de l’application.

Documentation :
- Mettre à jour la référence de la pile pour qu’elle corresponde aux dépendances et à la configuration réelles (Next 16, React 19, Tailwind 4, Supabase, PWA sans service worker, scripts npm et limitations de test).
- Documenter les notes de migration pour les mises à niveau Next.js 15→16 et React 18→19 afin de guider les futures modifications de code et l’utilisation des API.
- Corriger les chiffres de dette technique indiqués dans le CHANGELOG pour refléter l’état actuel de la base de code et préciser que les anciens éléments console.log/any/bg-[#] sont déjà résolus.
- Ajouter un document d’audit de migration dédié décrivant la migration manquante `profiles.locale`, ses risques, et une proposition de migration de rattrapage défensive pour une prochaine PR.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align documentation with the current IronTrack stack, tooling, and database migration state without changing application code.

Documentation:
- Update the stack reference to match the actual dependencies and configuration (Next 16, React 19, Tailwind 4, Supabase, PWA without service worker, npm scripts, and testing limitations).
- Document migration notes for the Next.js 15→16 and React 18→19 upgrades to guide future code changes and API usage.
- Correct the CHANGELOG’s reported technical debt figures to reflect the current codebase and clarify that the previous console.log/any/bg-[#] items are already resolved.
- Add a dedicated migration audit document describing the missing `profiles.locale` migration, its risks, and a proposed defensive catch-up migration for a follow-up PR.

</details>

</details>